### PR TITLE
Add minimal behat configuration file

### DIFF
--- a/frontend/tests/behat/minimal.yml
+++ b/frontend/tests/behat/minimal.yml
@@ -1,0 +1,17 @@
+default:
+    autoload:
+        '': %paths.base%/bootstrap
+    suites:
+
+        main:
+            description: End to end journey
+            paths:    [ %paths.base%/features ]
+            contexts:
+               - AppBundle\Behat\FeatureContext
+
+    extensions:
+        Behat\Symfony2Extension:
+        Behat\MinkExtension\ServiceContainer\MinkExtension:
+              goutte:
+                  guzzle_parameters:
+                    verify: false


### PR DESCRIPTION
Adds a behat.yml that does not contain a base_url. 
We will set the base_url via BEHAT_PARAMS environment variable.