### PR TITLE
Make DB parameters optional

### DIFF
--- a/app/config/config.yml
+++ b/app/config/config.yml
@@ -72,11 +72,11 @@ monolog:
 doctrine:
   dbal:
     driver:   pdo_pgsql
-    host:     "%database_host%"
-    port:     "%database_port%"
-    dbname:   "%database_name%"
-    user:     "%database_user%"
-    password: "%database_password%"
+    host:     "%env(DC_DB_HOST)%"
+    port:     "%env(DC_DB_PORT)%"
+    dbname:   "%env(DC_DB_NAME)%"
+    user:     "%env(DC_DB_USER)%"
+    password: "%env(DC_DB_PASS)%"
     charset:  UTF8
       #options:
     #sslmode: require

--- a/app/config/parameters.yml
+++ b/app/config/parameters.yml
@@ -1,11 +1,11 @@
 # env vars set by docker-compose at runtime
 parameters:
     secret:   '%env(DC_SYMFONY_SECRET)%'
-    database_host: '%env(DC_DB_HOST)%'
-    database_port: '%env(DC_DB_PORT)%'
-    database_name: '%env(DC_DB_NAME)%'
-    database_user: '%env(DC_DB_USER)%'
-    database_password:  '%env(DC_DB_PASS)%'
+    env(DC_DB_HOST): ""
+    env(DC_DB_PORT): ""
+    env(DC_DB_NAME): ""
+    env(DC_DB_USER): ""
+    env(DC_DB_PASS): ""
 
     # allow environment override, but set sensible default
     env(DYNAMODB_ENDPOINT): https://dynamodb.eu-west-1.amazonaws.com:443


### PR DESCRIPTION
Requiring DB parameters causes Behat to fail on first run