### PR TITLE
switch to localstack for S3 endpoint in .env

### DIFF
--- a/.env
+++ b/.env
@@ -32,7 +32,7 @@ DC_DB_USER=serve-opg
 DC_GTM=null
 
 DC_S3_BUCKET_NAME=test_bucket
-DC_S3_ENDPOINT=https://s3-eu-west-1.amazonaws.com
+DC_S3_ENDPOINT=http://localstack:4572
 DC_S3_REGION=eu-west-1
 DC_SIRIUS_URL=http://sirius-api:4010/
 INFRA_VERSION=0-local-infra


### PR DESCRIPTION
I got the value for this the wrong way round originally - it should be the localstack endpoint in .env so development behat tests pass and then the infra env var should be the real endpoint value.

As with the last PR, this will be reverted once deployment catch 22 is over.