### PR TITLE
266 remove limit from report

### DIFF
--- a/src/Repository/OrderRepository.php
+++ b/src/Repository/OrderRepository.php
@@ -27,11 +27,11 @@ class OrderRepository extends EntityRepository
 
     /**
      * @param array $filters
-     * @param integer $maxResults
+     * @param integer|null $maxResults
      *
      * @return Order[]
      */
-    public function getOrders(array $filters, $maxResults)
+    public function getOrders(array $filters)
     {
         /**
          * If the order is served, we order using the inverse (-) servedBy date, otherwise we use the issued date.
@@ -58,10 +58,6 @@ class OrderRepository extends EntityRepository
             ->leftJoin('o.client', 'c')
             ->orderBy('custom_ordering', 'ASC');
 
-        if ($maxResults) {
-            $qb->setMaxResults($maxResults);
-        }
-
         $this->applyFilters($qb, $filters);
 
         return $qb->getQuery()->getResult();
@@ -82,6 +78,10 @@ class OrderRepository extends EntityRepository
         if ($filters['q'] ?? false) {
             $qb->andWhere('UPPER(c.caseNumber) LIKE :cn')
             ->setParameter('cn', strtoupper(trim($filters['q'])));
+        }
+
+        if ($filters['maxResults']) {
+            $qb->setMaxResults($filters['maxResults']);
         }
     }
 

--- a/src/Service/ReportService.php
+++ b/src/Service/ReportService.php
@@ -38,7 +38,7 @@ class ReportService
      */
     public function generateCsv(int $maxResults=null)
     {
-        $orders = $this->getOrders($maxResults);
+        $orders = $this->getServedOrders($maxResults);
 
         $headers = ['DateIssued','DateServed', 'CaseNumber', 'AppointmentType', 'OrderType'];
         $ordersCsv = [];
@@ -72,12 +72,13 @@ class ReportService
      * @param int? $maxResult
      * @return Order[]
      */
-    public function getOrders(int $maxResult=null)
+    public function getServedOrders(int $maxResult=null)
     {
         $filters = [
-            'type' => 'served'
+            'type' => 'served',
+            'maxResults' => $maxResult
         ];
-        return $this->orderRepo->getOrders($filters, $maxResult);
+        return $this->orderRepo->getOrders($filters);
     }
 
     public function getCasesBeforeGoLive() {


### PR DESCRIPTION
## Description

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Issues Resolved

Removes limit from retrieving served orders during report CSV generation.

## Merge check List

- [x] New functionality includes testing
- [ ] New functionality has been documented in the README if applicable
- [ ] Approved by Sean
