### PR TITLE
fixes missing var error when deleting uploaded doc

### DIFF
--- a/src/Controller/DocumentController.php
+++ b/src/Controller/DocumentController.php
@@ -248,7 +248,7 @@ class DocumentController extends AbstractController
             $documentRemoved = $this->removeDocument($id);
             $error = '';
         } catch (\Throwable $e) {
-            $documentRemoved = 0;
+            $documentRemoved = self::ERROR;
             $error = $e;
         }
         $order = $this->orderService->getOrderByIdIfNotServed($orderId);


### PR DESCRIPTION
## Description

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Issues Resolved

Delete action for documents was returning a JSON string comprised of vars that were not defined in some instances. This fix defines vars and assigns the required values.

## Merge check List

- [ ] New functionality includes testing
- [ ] New functionality has been documented in the README if applicable
- [ ] Approved by Sean
