### PR TITLE
drops duplicate test setup steps

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -63,10 +63,6 @@ jobs:
       - run:
           name: Integration Test
           command: |
-            ./generate_certs.sh
-            docker-compose up --build -d loadbalancer
-            docker-compose run --rm waitforit -address=tcp://loadbalancer:443 -debug -timeout 120
-            docker-compose run --rm waitforit -address=tcp://postgres:5432 -debug
             docker-compose run --rm app php bin/console doctrine:fixtures:load --group=behatTests --purge-with-truncate --no-interaction
             docker-compose run --rm behat --suite=local
       - store_test_results:


### PR DESCRIPTION
## Description

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Issues Resolved

As part of getting the pipeline to work for database based unit tests we were running the app startup steps twice. I've dropped the duplicated set up steps from the integration test section and the total running time has dropped by about a minute.

## Merge check List

- [ ] New functionality includes testing
- [ ] New functionality has been documented in the README if applicable
- [ ] Approved by Sean
