### PR TITLE
Upgrade Postgres to 10.7

### DIFF
--- a/config/packages/doctrine.yaml
+++ b/config/packages/doctrine.yaml
@@ -15,7 +15,7 @@ doctrine:
         user:     "%env(DC_DB_USER)%"
         password: "%env(DC_DB_PASS)%"
         charset:  UTF8
-        server_version: 9.6
+        server_version: 10.7
         #options:
         #sslmode: require
     orm:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -89,7 +89,7 @@ services:
       - ./localstack-data:/tmp/localstack/data
 
   postgres:
-    image: postgres:9.6-alpine
+    image: postgres:10.7-alpine
     environment:
       POSTGRES_HOST: postgres
       POSTGRES_DB: serve-opg


### PR DESCRIPTION
## Description
In DDPB-2861, we want to start using Serverless Postgres. However, this only supports the latest version of Postgres so we need to upgrade to 10.7

This change performs the upgrade in the local docker stack, and also updates Doctrine's configuration to support 10.7.

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Issues Resolved

Dependency of [DDPB-2861](https://opgtransform.atlassian.net/browse/DDPB-2861) and [serve-opg-infrastructure#115](https://github.com/ministryofjustice/serve-opg-infrastructure/pull/115)

## Merge check List

- [x] New functionality includes testing
  - N/A, just want existing tests to still pass
- [x] New functionality has been documented in the README if applicable
  - README doesn't mention version number
- [ ] Approved by Sean
