### PR TITLE
Upgrade postgres to 10.7 to match RDS

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -89,7 +89,7 @@ services:
       - ./localstack-data:/tmp/localstack/data
 
   postgres:
-    image: postgres:9.6-alpine
+    image: postgres:10.7-alpine
     environment:
       POSTGRES_HOST: postgres
       POSTGRES_DB: serve-opg


### PR DESCRIPTION
## Description
In the real world, we're using Postgres 10.7 while we're still relying on 9.6 in the Docker image. This change aligns the versions.