### PR TITLE
DDPB-2990: Output packages and versions in CI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -21,7 +21,7 @@ jobs:
             # & wait for the server to become available
             docker-compose up -d localstack
 
-            docker-compose run --rm waitforit -address=http://localstack:4572 -debug
+            docker-compose run --rm waitforit -address=http://localstack:4572 -debug -timeout=30
             docker-compose run --rm aws --endpoint-url=http://localstack:4572 s3 mb s3://sirius_test_bucket
             docker-compose run --rm aws --endpoint-url=http://localstack:4572 s3 mb s3://test_bucket
 

--- a/Makefile
+++ b/Makefile
@@ -51,7 +51,7 @@ build-deps: ## Runs through all steps required before the app can be brought up
 	# Create the s3 buckets, generate localstack data in /localstack-data
 	# & wait for the server to become available
 	docker-compose up -d localstack
-	docker-compose run --rm waitforit -address=http://localstack:4572 -debug
+	docker-compose run --rm waitforit -address=http://localstack:4572 -debug -timeout=30
 	docker-compose run --rm aws --endpoint-url=http://localstack:4572 s3 mb s3://sirius_test_bucket
 	docker-compose run --rm aws --endpoint-url=http://localstack:4572 s3 mb s3://test_bucket
 

--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ sudo security add-trusted-cert -d -r trustRoot \
 # Create the s3 buckets, generate localstack data in /localstack-data
 # & wait for the server to become available
 docker-compose up -d localstack
-docker-compose run --rm waitforit -address=http://localstack:4572 -debug
+docker-compose run --rm waitforit -address=http://localstack:4572 -debug -timeout=30
 docker-compose run --rm aws --endpoint-url=http://localstack:4572 s3 mb s3://sirius_test_bucket
 docker-compose run --rm aws --endpoint-url=http://localstack:4572 s3 mb s3://test_bucket
 
@@ -175,7 +175,7 @@ docker-compose exec app rm -rf /var/www/var/cache /tmp/app-cache
 # Xdebug
 To enable Xdebug running via Docker in PHPStorm you will need to:
 
-- In `Preferences > Build, Execution, Deployment > Docker` select `Docker for Mac` 
+- In `Preferences > Build, Execution, Deployment > Docker` select `Docker for Mac`
 - In `Preferences > Languages and Frameworks > PHP` Click the `...` button next to `CLI Interpreter`
 - Click the `+` button to add a new CLI  and select `From Docker, Vagrant, VM, Remote`
 - Select `Docker Compose`, for `Server` choose `Docker` and select `app` for Service. Click `OK` and `Apply`.


### PR DESCRIPTION
# Description

It's hard to identify what CVEs Serve OPG might be vulnerable to, because it's unclear what software versions it's running. This change adds a step to CircleCI to output those versions for easy comparison.

This needed to be slightly different than Complete the deputy report: because Serve OPG doesn't install any PHP extensions, it doesn't install `php7-common` which would indicate the PHP version. Therefore I've had to additionally run `php -v` to capture that.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Issues Resolved

[DDPB-2990](https://opgtransform.atlassian.net/browse/DDPB-2990)

## Merge check List

- [ ] New functionality includes testing
- [ ] New functionality has been documented in the README if applicable
- [ ] Approved by Sean
