### PR TITLE
Always use composer on app container

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -83,7 +83,7 @@ jobs:
           name: Build
           command: |
             # Vendor php dependencies
-            docker-compose run --rm composer
+            docker-compose run --rm app composer install --no-interaction
             # install js dependencies
             docker-compose run --rm yarn install
             # Generate static assets

--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ docker-compose run --rm aws --region eu-west-1 --endpoint-url=http://localstack:
 docker-compose run --rm aws --region eu-west-1 --endpoint-url=http://localstack:4569 dynamodb create-table --cli-input-json file://sessions_table.json
 
 # Vendor php dependencies
-docker-compose run --rm composer
+docker-compose run --rm app composer install --no-interaction
 
 # Install javascript dependencies
 docker-compose run --rm yarn


### PR DESCRIPTION
## Description
#365 [failed to build](https://app.circleci.com/jobs/github/ministryofjustice/serve-opg/1733) because the master build process still refers to the `composer` container, which we have now removed.

This updates the pipeline (and README) to install on the app image instead.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Issues Resolved

DDPB-2961

## Merge check List

- [ ] New functionality includes testing
- [ ] New functionality has been documented in the README if applicable
- [ ] Approved by Sean
