### PR TITLE
Use cookie as fallback for CSRF header not being present

### DIFF
--- a/src/Service/SiriusService.php
+++ b/src/Service/SiriusService.php
@@ -117,7 +117,11 @@ class SiriusService
                     // Make API call
                     $this->logger->debug('Begin API call:');
 
-                    $csrfToken = $apiResponse->getHeader('X-XSRF-TOKEN')[0];
+                    if ($apiResponse->hasHeader('X-XSRF-TOKEN')) {
+                        $csrfToken = $apiResponse->getHeader('X-XSRF-TOKEN')[0];
+                    } else {
+                        $csrfToken = urldecode($this->cookieJar->getCookieByName('XSRF-TOKEN')->getValue());
+                    }
 
                     $apiResponse = $this->sendOrderToSirius($payload, $csrfToken);
 
@@ -179,6 +183,7 @@ class SiriusService
         $this->logger->debug('Logging in to ' .
             $this->httpClient->getConfig('base_uri') .
             ', with params => ' . json_encode($params));
+
         return $this->httpClient->post(
             'auth/login',
             $params


### PR DESCRIPTION
## Description
We get the CSRF token back in cookies on a successful auth rather than a header like other requests. I've had to leave the header check in for now as OpenAPI3 doesn't seem to support defining a cookie response which would mean tests that rely on using the fake prism server would fail. We'll need to look at this at some point and work out a proper way of handling it.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Issues Resolved

Fixes DDPB-3416

## Merge check List

- [x] New functionality includes testing
- [ ] New functionality has been documented in the README if applicable
- [ ] Approved by PMs
