### PR TITLE
DDPB-3705: Make date of birth and address fields mandatory

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,5 +1,5 @@
 ---
-version: '3'
+version: "3"
 
 services:
   aws:
@@ -27,10 +27,9 @@ services:
     depends_on:
       - web
     environment:
-      DHPARAM_GENERATION: 'false'
+      DHPARAM_GENERATION: "false"
       DEFAULT_HOST: localhost
       CERT_NAME: web.crt
-
 
   web:
     build:
@@ -54,14 +53,14 @@ services:
     image: 311462405659.dkr.ecr.eu-west-1.amazonaws.com/serve-opg/app:latest
     env_file:
       - .env
-#    Setting here rather than .env to stop them being overwritten during build steps on prod
+      - .env.local
+    #    Setting here rather than .env to stop them being overwritten during build steps on prod
     environment:
       - AWS_ACCESS_KEY_ID=foo
       - AWS_SECRET_ACCESS_KEY=bar
       - DC_BEHAT_CONTROLLER_ENABLED=1
       - DC_S3_ENDPOINT=http://localstack:4572
       - DYNAMODB_ENDPOINT=http://localstack:4569
-      - NOTIFICATION_API_KEY=fake-key1234-replace-with-key-from-notify45566-if-you-need-to-test-locally
       - OS_PLACES_API_KEY=DUMMY_KEY
       - SIRIUS_PUBLIC_API_PASSWORD=FAKE_API_PASSWORD
       - APP_SECRET=aFakeSecret

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -53,7 +53,6 @@ services:
     image: 311462405659.dkr.ecr.eu-west-1.amazonaws.com/serve-opg/app:latest
     env_file:
       - .env
-      - .env.local
     #    Setting here rather than .env to stop them being overwritten during build steps on prod
     environment:
       - AWS_ACCESS_KEY_ID=foo

--- a/src/Entity/Deputy.php
+++ b/src/Entity/Deputy.php
@@ -58,6 +58,7 @@ class Deputy
      * @var \DateTime
      *
      * @ORM\Column(name="dob", type="date", nullable=true)
+     * @Assert\NotBlank(message="deputy.dateOfBirth.notBlank", groups={"deputy-add"})
      */
     private $dateOfBirth;
 
@@ -65,6 +66,7 @@ class Deputy
      * @var string
      *
      * @ORM\Column(name="email_address", type="string", length=255, nullable=true)
+     * @Assert\NotBlank(message="deputy.emailAddress.notBlank", groups={"deputy-add"})
      */
     private $emailAddress;
 
@@ -93,6 +95,7 @@ class Deputy
      * @var string
      *
      * @ORM\Column(name="address_line_1", type="string", length=255, nullable=true)
+     * @Assert\NotBlank(message="deputy.address_line_1.notBlank", groups={"deputy-add"})
      */
     private $addressLine1;
 
@@ -114,6 +117,7 @@ class Deputy
      * @var string
      *
      * @ORM\Column(name="address_town", type="string", length=255, nullable=true)
+     * @Assert\NotBlank(message="deputy.address_town.notBlank", groups={"deputy-add"})
      */
     private $addressTown;
 
@@ -128,6 +132,7 @@ class Deputy
      * @var string
      *
      * @ORM\Column(name="address_postcode", type="string", length=255, nullable=true)
+     * @Assert\NotBlank(message="deputy.address_postcode.notBlank", groups={"deputy-add"})
      */
     private $addressPostcode;
 

--- a/src/Entity/Deputy.php
+++ b/src/Entity/Deputy.php
@@ -8,6 +8,8 @@ use Doctrine\ORM\Mapping as ORM;
 use Symfony\Component\Security\Core\User\UserInterface;
 use Symfony\Component\Security\Core\User\EquatableInterface;
 use Symfony\Component\Security\Core\User\AdvancedUserInterface;
+use Symfony\Component\Validator\Constraints as Assert;
+
 
 /**
  * @ORM\Entity
@@ -58,7 +60,7 @@ class Deputy
      * @var \DateTime
      *
      * @ORM\Column(name="dob", type="date", nullable=true)
-     * @Assert\NotBlank(message="deputy.dateOfBirth.notBlank", groups={"deputy-add"})
+     * @Assert\NotBlank(message="deputy.dateOfBirth.notBlank")
      */
     private $dateOfBirth;
 
@@ -66,7 +68,7 @@ class Deputy
      * @var string
      *
      * @ORM\Column(name="email_address", type="string", length=255, nullable=true)
-     * @Assert\NotBlank(message="deputy.emailAddress.notBlank", groups={"deputy-add"})
+     * @Assert\NotBlank(message="deputy.emailAddress.notBlank")
      */
     private $emailAddress;
 
@@ -95,7 +97,7 @@ class Deputy
      * @var string
      *
      * @ORM\Column(name="address_line_1", type="string", length=255, nullable=true)
-     * @Assert\NotBlank(message="deputy.address_line_1.notBlank", groups={"deputy-add"})
+     * @Assert\NotBlank(message="deputy.address_line_1.notBlank")
      */
     private $addressLine1;
 
@@ -117,7 +119,7 @@ class Deputy
      * @var string
      *
      * @ORM\Column(name="address_town", type="string", length=255, nullable=true)
-     * @Assert\NotBlank(message="deputy.address_town.notBlank", groups={"deputy-add"})
+     * @Assert\NotBlank(message="deputy.address_town.notBlank")
      */
     private $addressTown;
 
@@ -132,7 +134,7 @@ class Deputy
      * @var string
      *
      * @ORM\Column(name="address_postcode", type="string", length=255, nullable=true)
-     * @Assert\NotBlank(message="deputy.address_postcode.notBlank", groups={"deputy-add"})
+     * @Assert\NotBlank(message="deputy.address_postcode.notBlank")
      */
     private $addressPostcode;
 

--- a/src/Entity/Order.php
+++ b/src/Entity/Order.php
@@ -160,15 +160,17 @@ abstract class Order
      * @param Client $client
      * @param DateTime $madeAt Date Order was first made, outside DC
      * @param DateTime $issuedAt Date Order was issues at
+     * @param string $createdAt
+     *
      * @throws Exception
      */
-    public function __construct(Client $client, DateTime $madeAt, DateTime $issuedAt)
+    public function __construct(Client $client, DateTime $madeAt, DateTime $issuedAt, string $createdAt = 'now')
     {
         $this->client = $client;
         $this->madeAt = $madeAt;
         $this->issuedAt = $issuedAt;
 
-        $this->createdAt = new DateTime();
+        $this->createdAt = new DateTime($createdAt);
         $this->deputies = new ArrayCollection();
         $this->documents = new ArrayCollection();
 

--- a/src/Form/DeputyForm.php
+++ b/src/Form/DeputyForm.php
@@ -42,7 +42,7 @@ class DeputyForm extends AbstractType
             ])
             ->add('dateOfBirth', BirthdayType::class, [
                 'label' => 'deputy.dateOfBirth.label',
-                'required' => false,
+                'required' => true,
                 'widget' => 'text',
                 'placeholder' => array(
                     'day' => 'Day','month' => 'Month' , 'year' => 'Year'
@@ -51,7 +51,6 @@ class DeputyForm extends AbstractType
             ])
             ->add('emailAddress', TextType::class, [
                 'label' => 'deputy.emailAddress.label',
-                'hint' => 'deputy.emailAddress.hint',
                 'required' => false,
                 'attr' => ['maxlength'=> 255]
             ])
@@ -71,7 +70,7 @@ class DeputyForm extends AbstractType
                 'attr' => ['maxlength'=> 255]
             ])
             ->add('addressLine1', TextType::class, [
-                'required' => false,
+                'required' => true,
                 'attr' => ['maxlength'=> 255]
             ])
             ->add('addressLine2', TextType::class, [
@@ -84,7 +83,7 @@ class DeputyForm extends AbstractType
             ])
             ->add('addressTown', TextType::class, [
                 'label' => 'deputy.addressTown',
-                'required' => false,
+                'required' => true,
                 'attr' => ['maxlength'=> 255]
             ])
             ->add('addressCounty', TextType::class, [
@@ -94,7 +93,7 @@ class DeputyForm extends AbstractType
             ])
             ->add('addressPostcode', TextType::class, [
                 'label' => 'deputy.addressPostcode',
-                'required' => false,
+                'required' => true,
                 'attr' => ['maxlength'=> 255]
             ])
             ->add('saveAndContinue', SubmitType::class);

--- a/src/TestHelpers/OrderTestHelper.php
+++ b/src/TestHelpers/OrderTestHelper.php
@@ -21,16 +21,16 @@ class OrderTestHelper
      * @return Order
      * @throws Exception
      */
-    static public function generateOrder(string $madeAt, string $issuedAt, string $caseNumber, string $orderType)
+    public static function generateOrder(string $madeAt, string $issuedAt, string $caseNumber, string $orderType, string $createdAt = 'now')
     {
         $orderMadeDate = new DateTime($madeAt);
         $orderIssuedDate = new DateTime($issuedAt);
         $client = new Client($caseNumber, 'Bob Bobbins', $orderIssuedDate);
 
         if ($orderType === 'HW') {
-            $order = new OrderHw($client, $orderMadeDate, $orderIssuedDate);
+            $order = new OrderHw($client, $orderMadeDate, $orderIssuedDate, $createdAt);
         } elseif ($orderType === 'PF') {
-            $order = new OrderPf($client, $orderMadeDate, $orderIssuedDate);
+            $order = new OrderPf($client, $orderMadeDate, $orderIssuedDate, $createdAt);
         } else {
             throw new Exception('$orderType should be either HW or PF');
         }
@@ -44,7 +44,7 @@ class OrderTestHelper
      * @return Order[]
      * @throws Exception
      */
-    static public function generateOrders(int $numberOfOrders, bool $setAsServed)
+    public static function generateOrders(int $numberOfOrders, bool $setAsServed)
     {
         $orders = [];
         $lastOrderNumber = 99900000 + $numberOfOrders;
@@ -74,14 +74,14 @@ class OrderTestHelper
      */
     protected static function sortOrdersByDateAscending(array $orders, string $datePropertyName): array
     {
-        switch ($datePropertyName){
+        switch ($datePropertyName) {
             case 'issuedAt':
-                usort($orders, function($a, $b) {
+                usort($orders, function ($a, $b) {
                     strtotime($a->getIssuedAt()->format('Y-m-d')) - strtotime($b->getIssuedAt()->format('Y-m-d'));
                 });
                 return $orders;
             case 'servedAt':
-                usort($orders, function($a, $b) {
+                usort($orders, function ($a, $b) {
                     strtotime($a->getServedAt()->format('Y-m-d')) - strtotime($b->getServedAt()->format('Y-m-d'));
                 });
                 return $orders;

--- a/tests/Entity/DeputyTest.php
+++ b/tests/Entity/DeputyTest.php
@@ -1,0 +1,32 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Entity;
+
+use App\Entity\Deputy;
+use DateTime;
+use App\TestHelpers\OrderTestHelper;
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\Validator\Validation;
+
+class DeputyTest extends TestCase
+{
+    public function testDeputyBlankFields()
+    {
+        $timeNow = new DateTime('now');
+
+        $deputy = new Deputy(OrderTestHelper::generateOrder('2016-01-01', '2016-01-02', '16472847', 'HW', $timeNow->format('Y-m-d')));
+
+        $deputy->setDateOfBirth(NULL);
+        $deputy->setEmailAddress('');
+        $deputy->setAddressLine1('');
+        $deputy->setAddressTown('');
+        $deputy->setAddressPostcode('');
+
+        $validator = Validation::createValidatorBuilder()->enableAnnotationMapping()->getValidator();
+        $errors = $validator->validate($deputy);
+
+        $this->assertEquals(5, count($errors));
+    }
+}

--- a/tests/Form/DeputyFormTest.php
+++ b/tests/Form/DeputyFormTest.php
@@ -1,0 +1,48 @@
+<?php
+
+use App\Entity\Deputy;
+use App\Form\DeputyForm;
+use App\TestHelpers\OrderTestHelper;
+use Symfony\Component\Form\Test\TypeTestCase;
+
+class DeputyFormTest extends TypeTestCase
+{
+    public function testSubmitValidData()
+    {
+        $timeNow = new DateTime('now');
+
+        $formData = [
+            'deputyType' => 'LAY',
+            'forename' => 'John',
+            'surname' => 'Doe',
+            'dateOfBirth' => [
+                'day' => '1',
+                'month' => '1',
+                'year' => '1990'
+            ],
+            'emailAddress' => 'email@example.org',
+            'addressLine1' => '10 Downing Street',
+            'addressTown' => 'London',
+            'addressPostcode' => 'SW1A 2AA',
+        ];
+
+        $model = new Deputy(OrderTestHelper::generateOrder('2016-01-01', '2016-01-02', '16472847', 'HW', $timeNow->format('Y-m-d')));
+
+        $form = $this->factory->create(DeputyForm::class, $model);
+
+        $expected = new Deputy(OrderTestHelper::generateOrder('2016-01-01', '2016-01-02', '16472847', 'HW', $timeNow->format('Y-m-d')));
+        $expected->setDeputyType('LAY');
+        $expected->setForename('John');
+        $expected->setSurname('Doe');
+        $expected->setDateOfBirth(new DateTime('01-01-1990'));
+        $expected->setEmailAddress('email@example.org');
+        $expected->setAddressLine1('10 Downing Street');
+        $expected->setAddressTown('London');
+        $expected->setAddressPostcode('SW1A 2AA');
+
+        $form->submit($formData);
+
+        $this->assertTrue($form->isSynchronized());
+        $this->assertEquals($expected, $model);
+    }
+}

--- a/translations/validators.en.yml
+++ b/translations/validators.en.yml
@@ -26,3 +26,14 @@ user:
       noLowerCaseChars: The password must have at least one lowercase letter
       noUpperCaseChars: The password must have at least one capital letter
       noNumber: The password must have at least one number
+deputy:
+   dateOfBirth:
+      notBlank: Enter a date of birth
+   emailAddress:
+      notBlank: Enter a email address
+   address_line_1:
+      notBlank: Enter first line of address
+   address_town:
+      notBlank: Enter town of the address
+   address_postcode:
+      notBlank: Enter postcode of the address


### PR DESCRIPTION
## Description
As a OPG user
I want the COP users to enter the deputy DOB and I want the COP users to enter the deputy address
So that the deputy can be matched when the order is served and duplicates are not created in Sirius

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Merge check List

- [X] New functionality includes testing
- [ ] New functionality has been documented in the README if applicable **N/A**
- [ ] Approved by PMs
