### PR TITLE
DDPB-3433: Add step to pipeline to run tests at 2AM daily

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -13,7 +13,8 @@ orbs:
               docker-username: DOCKER_USER
 
   test:
-    orbs: dockerhub_helper/dockerhub_login
+    orbs:
+      dockerhub_helper: dockerhub_helper
     commands:
       setup:
         steps:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -13,6 +13,7 @@ orbs:
               docker-username: DOCKER_USER
 
   test:
+    orbs: dockerhub_helper/dockerhub_login
     commands:
       setup:
         steps:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -12,10 +12,7 @@ orbs:
               docker-password: DOCKER_ACCESS_TOKEN
               docker-username: DOCKER_USER
 
-jobs:
-  test:
-    machine:
-      image: ubuntu-2004:202010-01
+  test-setup:
     steps:
       - checkout
       - dockerhub_helper/dockerhub_login
@@ -61,11 +58,18 @@ jobs:
       - save_cache:
           key: vendor-{{ checksum "composer.lock" }}
           paths:
-          - vendor
+            - vendor
       - save_cache:
           key: node_modules-{{ checksum "yarn.lock" }}
           paths:
             - node_modules
+
+jobs:
+  test:
+    machine:
+      image: ubuntu-2004:202010-01
+    steps:
+      - test-setup
       - run:
           name: Unit Test
           command: |
@@ -129,17 +133,22 @@ jobs:
             docker push 311462405659.dkr.ecr.eu-west-1.amazonaws.com/serve-opg/web:$CIRCLE_BUILD_NUM
             curl --silent --show-error --fail -X POST "https://circleci.com/api/v1.1/project/github/ministryofjustice/serve-opg-infrastructure/build?circle-token=${CIRCLE_API_TOKEN}"
 
+
+
 workflows:
   version: 2
   build:
     jobs:
     - test:
-        filters:
-          branches:
-            ignore:
-            - master
+        filters: { branches: { ignore: [master] } }
     - build:
-        filters:
-          branches:
-            only:
-            - master
+        filters: { branches: { only: [master] } }
+
+  weekly_integration_run:
+    triggers:
+      - schedule:
+#          Run at 2AM daily
+          cron: "0 2 * * *"
+          filters: { branches: { only: [ master ] } }
+    jobs:
+      - test

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -13,13 +13,9 @@ orbs:
               docker-username: DOCKER_USER
 
   test:
-    orbs:
-      dockerhub_helper: dockerhub_helper
     commands:
       setup:
         steps:
-          - checkout
-          - dockerhub_helper/dockerhub_login
           - restore_cache:
               keys:
                 - vendor-{{ checksum "composer.lock" }}
@@ -92,6 +88,8 @@ jobs:
     machine:
       image: ubuntu-2004:202010-01
     steps:
+      - checkout
+      - dockerhub_helper/dockerhub_login
       - test/setup
       - test/unit
       - test/integration

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -86,8 +86,8 @@ orbs:
 jobs:
   test:
     machine:
-      image: cimg/base:2020.11
-    resource_class: small
+      image: ubuntu-2004:202010-01
+    resource_class: gpu.small
     steps:
       - checkout
       - dockerhub_helper/dockerhub_login
@@ -102,9 +102,8 @@ jobs:
           path: ./tests/artifacts
 
   build:
-    machine:
-      image: cimg/base:2020.11
-    resource_class: small
+    machine: true
+    resource_class: gpu.small
     steps:
       - add_ssh_keys:
           fingerprints:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -86,7 +86,7 @@ orbs:
 jobs:
   test:
     machine:
-      image: ubuntu-2004:202010-01
+      image: cimg/base:2020.11
     resource_class: small
     steps:
       - checkout
@@ -102,7 +102,8 @@ jobs:
           path: ./tests/artifacts
 
   build:
-    machine: true
+    machine:
+      image: cimg/base:2020.11
     resource_class: small
     steps:
       - add_ssh_keys:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -87,7 +87,6 @@ jobs:
   test:
     machine:
       image: ubuntu-2004:202010-01
-    resource_class: gpu.small
     steps:
       - checkout
       - dockerhub_helper/dockerhub_login
@@ -103,7 +102,6 @@ jobs:
 
   build:
     machine: true
-    resource_class: gpu.small
     steps:
       - add_ssh_keys:
           fingerprints:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -12,77 +12,87 @@ orbs:
               docker-password: DOCKER_ACCESS_TOKEN
               docker-username: DOCKER_USER
 
-  test-setup:
-    steps:
-      - checkout
-      - dockerhub_helper/dockerhub_login
-      - restore_cache:
-          keys:
-            - vendor-{{ checksum "composer.lock" }}
-      - restore_cache:
-          keys:
-            - node_modules-{{ checksum "yarn.lock" }}
-      - run:
-          name: Build Dependencies
-          command: |
-            pip install --quiet awscli
-            pyenv rehash
+  test:
+    commands:
+      setup:
+        steps:
+          - checkout
+          - dockerhub_helper/dockerhub_login
+          - restore_cache:
+              keys:
+                - vendor-{{ checksum "composer.lock" }}
+          - restore_cache:
+              keys:
+                - node_modules-{{ checksum "yarn.lock" }}
+          - run:
+              name: Build Dependencies
+              command: |
+                pip install --quiet awscli
+                pyenv rehash
 
-            # Create the s3 buckets
-            # & wait for the server to become available
-            docker-compose up -d localstack
+                # Create the s3 buckets
+                # & wait for the server to become available
+                docker-compose up -d localstack
 
-            docker-compose run --rm waitforit -address=http://localstack:4572 -debug -timeout=30
-            docker-compose run --rm aws --endpoint-url=http://localstack:4572 s3 mb s3://sirius_test_bucket
-            docker-compose run --rm aws --endpoint-url=http://localstack:4572 s3 mb s3://test_bucket
+                docker-compose run --rm waitforit -address=http://localstack:4572 -debug -timeout=30
+                docker-compose run --rm aws --endpoint-url=http://localstack:4572 s3 mb s3://sirius_test_bucket
+                docker-compose run --rm aws --endpoint-url=http://localstack:4572 s3 mb s3://test_bucket
 
-            # Create dynamodb tables
-            docker-compose run --rm aws --region eu-west-1 --endpoint-url=http://localstack:4569 dynamodb create-table --cli-input-json file://attempts_table.json
-            docker-compose run --rm aws --region eu-west-1 --endpoint-url=http://localstack:4569 dynamodb create-table --cli-input-json file://sessions_table.json
+                # Create dynamodb tables
+                docker-compose run --rm aws --region eu-west-1 --endpoint-url=http://localstack:4569 dynamodb create-table --cli-input-json file://attempts_table.json
+                docker-compose run --rm aws --region eu-west-1 --endpoint-url=http://localstack:4569 dynamodb create-table --cli-input-json file://sessions_table.json
 
-            # Triggers Symfony Flex to run recipes during composer install - required for phpunit-bridge
-            rm -rf vendor
-            rm -rf symfony.lock
+                # Triggers Symfony Flex to run recipes during composer install - required for phpunit-bridge
+                rm -rf vendor
+                rm -rf symfony.lock
 
-            # Vendor php dependencies
-            docker-compose run --rm app composer install --no-interaction
+                # Vendor php dependencies
+                docker-compose run --rm app composer install --no-interaction
 
-            # Install js dependencies
-            docker-compose run --rm yarn install
+                # Install js dependencies
+                docker-compose run --rm yarn install
 
-            # Generate static assets
-            docker-compose run --rm yarn build-dev
+                # Generate static assets
+                docker-compose run --rm yarn build-dev
 
-            # Removes boilerplate feature test added during Symfony Flex recipe for behat
-            rm -rf features/demo.feature
-      - save_cache:
-          key: vendor-{{ checksum "composer.lock" }}
-          paths:
-            - vendor
-      - save_cache:
-          key: node_modules-{{ checksum "yarn.lock" }}
-          paths:
-            - node_modules
+                # Removes boilerplate feature test added during Symfony Flex recipe for behat
+                rm -rf features/demo.feature
+          - save_cache:
+              key: vendor-{{ checksum "composer.lock" }}
+              paths:
+                - vendor
+          - save_cache:
+              key: node_modules-{{ checksum "yarn.lock" }}
+              paths:
+                - node_modules
+#      Requires test/setup
+      unit:
+        steps:
+          - run:
+              name: Unit Test
+              command: |
+                ./generate_certs.sh
+                docker-compose -f docker-compose.test.yml -f docker-compose.yml up --build -d loadbalancer
+                docker-compose run --rm waitforit -address=tcp://loadbalancer:443 -debug -timeout 120
+                docker-compose run --rm waitforit -address=tcp://postgres:5432 -debug
+                docker-compose -f docker-compose.test.yml -f docker-compose.yml run --rm app php bin/phpunit --verbose tests --log-junit /var/www/tests/artifacts/phpunit/junit.xml
+#      Requires test/setup
+      integration:
+        steps:
+          - run:
+              name: Integration Test
+              command: |
+                docker-compose run --rm app php bin/console doctrine:fixtures:load --group=behatTests --purge-with-truncate --no-interaction
+                docker-compose -f docker-compose.test.yml -f docker-compose.yml run --rm behat --suite=local
 
 jobs:
   test:
     machine:
       image: ubuntu-2004:202010-01
     steps:
-      - test-setup
-      - run:
-          name: Unit Test
-          command: |
-            ./generate_certs.sh
-            docker-compose -f docker-compose.test.yml -f docker-compose.yml up --build -d loadbalancer
-            docker-compose run --rm waitforit -address=tcp://loadbalancer:443 -debug -timeout 120
-            docker-compose run --rm waitforit -address=tcp://postgres:5432 -debug
-            docker-compose -f docker-compose.test.yml -f docker-compose.yml run --rm app php bin/phpunit --verbose tests --log-junit /var/www/tests/artifacts/phpunit/junit.xml
-      - run:
-          name: Integration Test
-          command: |
-            docker-compose run --rm app php bin/console doctrine:fixtures:load --group=behatTests --purge-with-truncate --no-interaction
-            docker-compose -f docker-compose.test.yml -f docker-compose.yml run --rm behat --suite=local
+      - test/setup
+      - test/unit
+      - test/integration
       - store_test_results:
           path: ./tests/artifacts
       - store_artifacts:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -87,6 +87,7 @@ jobs:
   test:
     machine:
       image: ubuntu-2004:202010-01
+    resource_class: small
     steps:
       - checkout
       - dockerhub_helper/dockerhub_login
@@ -102,6 +103,7 @@ jobs:
 
   build:
     machine: true
+    resource_class: small
     steps:
       - add_ssh_keys:
           fingerprints:
@@ -149,10 +151,10 @@ workflows:
   version: 2
   build:
     jobs:
-    - test:
-        filters: { branches: { ignore: [master] } }
-    - build:
-        filters: { branches: { only: [master] } }
+      - test:
+          filters: { branches: { ignore: [master] } }
+      - build:
+          filters: { branches: { only: [master] } }
 
   weekly_integration_run:
     triggers:


### PR DESCRIPTION
## Description
To have a minimal level of confidence in the integration with Sirius we should be running our integration tests at least daily. This change adds a cron job to do just that at 2AM each morning.

I've also taken the opportunity to break the circleci test steps up into some chunks to make re-use a little easier in the future. 

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Issues Resolved
DDPB-3433
