### PR TITLE
DDPB-3820 - Fix postcode lookup for Serve OPG

### DIFF
--- a/config/services.yaml
+++ b/config/services.yaml
@@ -54,7 +54,15 @@ services:
     App\Service\AddressLookup\OrdnanceSurvey:
         arguments:
             $apiKey: "%env(OS_PLACES_API_KEY)%"
-            $httpClient: "@guzzleClient"
+            $httpClient: "@OrdnanceGuzzleClient"
+
+    # OrdnanceSurvey (used for Postcode Lookup)
+    # Uses custom guzzle client to avoid autowiring with the other ones that might be used around
+    OrdnanceGuzzleClient:
+        class: GuzzleHttp\Client
+        arguments:
+            $config:
+                base_uri: "https://api.ordnancesurvey.co.uk/places/v1/addresses/postcode?"
 
     notificationHttpClient:
         class: Http\Adapter\Guzzle6\Client

--- a/src/Controller/PostcodeController.php
+++ b/src/Controller/PostcodeController.php
@@ -3,6 +3,7 @@
 namespace App\Controller;
 
 use App\Service\AddressLookup\OrdnanceSurvey;
+use Psr\Log\LoggerInterface;
 use Symfony\Bundle\FrameworkBundle\Controller\AbstractController;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\JsonResponse;
@@ -10,6 +11,20 @@ use Symfony\Component\Routing\Annotation\Route;
 
 class PostcodeController extends AbstractController
 {
+    /**
+     * @var LoggerInterface
+     */
+    private $logger;
+
+    /**
+     * PostcodeController constructor.
+     * @param LoggerInterface $logger
+     */
+    public function __construct(LoggerInterface $logger)
+    {
+        $this->logger = $logger;
+    }
+
     /**
      * @Route("/postcode-lookup", name="postcode-lookup")
      */
@@ -24,7 +39,7 @@ class PostcodeController extends AbstractController
         try {
             $addresses = $ordnanceSurvey->lookupPostcode($postcode);
         }catch (\Exception $e) {
-            $this->get('logger')->error("Exception from postcode lookup: ". $e->getMessage());
+            $this->logger->error("Exception from postcode lookup: ". $e->getMessage());
             return new JsonResponse([ 'error'=> $e->getMessage()]);
         }
 

--- a/src/Service/AddressLookup/OrdnanceSurvey.php
+++ b/src/Service/AddressLookup/OrdnanceSurvey.php
@@ -61,7 +61,6 @@ class OrdnanceSurvey
         $request = new Request('GET', $url);
         $response = $this->httpClient->send($request);
 
-
         if ($response->getStatusCode() != 200) {
             throw new \RuntimeException('Error retrieving address details: bad status code');
         }

--- a/src/Service/AddressLookup/OrdnanceSurvey.php
+++ b/src/Service/AddressLookup/OrdnanceSurvey.php
@@ -58,9 +58,10 @@ class OrdnanceSurvey
         $url = new Uri($this->httpClient->getConfig('base_uri'));
         $url = URI::withQueryValue($url, 'key', $this->apiKey);
         $url = URI::withQueryValue($url, 'postcode', $postcode);
-        $url = URI::withQueryValue($url, 'lr', $this->httpClient->getConfig('lr'));
         $request = new Request('GET', $url);
         $response = $this->httpClient->send($request);
+
+
         if ($response->getStatusCode() != 200) {
             throw new \RuntimeException('Error retrieving address details: bad status code');
         }

--- a/tests/Service/OrdnanceSurveyServiceTest.php
+++ b/tests/Service/OrdnanceSurveyServiceTest.php
@@ -31,7 +31,6 @@ class OrdnanceSurveyServiceTest extends MockeryTestCase
         $this->httpClient = Mockery::mock(Client::class);
         $this->httpClient->shouldReceive('getConfig')->with('base_uri');
         $this->httpClient->shouldReceive('getConfig')->with('apiKey');
-        $this->httpClient->shouldReceive('getConfig')->with('lr');
 
         $this->response = Mockery::mock(ResponseInterface::class);
 


### PR DESCRIPTION
## Description

Postcode lookup had missing configuration which led to all requests being sent out failing.
Has been fixed by giving the OrdnanceSurvey service it's own GuzzleClient config with required arguments.

Also fixed an issue with the logging of errors for the postcode lookup.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Issues Resolved

DDPB-3820

## Merge check List

- [ ] New functionality includes testing
- [ ] New functionality has been documented in the README if applicable
- [ ] Approved by PMs
