### PR TITLE
Lock PHP to 7.4.16

### DIFF
--- a/docker/app/Dockerfile
+++ b/docker/app/Dockerfile
@@ -1,4 +1,4 @@
-FROM php:7.4-fpm-alpine
+FROM php:7.4.16-fpm-alpine
 
 # Install postgresql drivers
 RUN apk add --no-cache postgresql-dev \

--- a/docker/notify/Dockerfile
+++ b/docker/notify/Dockerfile
@@ -1,4 +1,4 @@
-FROM php:7.4-fpm-alpine
+FROM php:7.4.16-fpm-alpine
 
 ENV APP_DIR /var/www/app
 RUN mkdir -p $APP_DIR


### PR DESCRIPTION
## Description
Locking for now to avoid postgres driver issues on 7.4.18 - https://bugs.php.net/bug.php?id=81002

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
