### PR TITLE
SER-81: Add endpoint for served order summary and link from served tab

### DIFF
--- a/serve-web/src/Controller/OrderController.php
+++ b/serve-web/src/Controller/OrderController.php
@@ -280,4 +280,21 @@ MESSAGE;
             ['order' => $order, 'form' => $form->createView()]
         );
     }
+
+    /**
+     * @Route("/order/{orderId}/summary-served", name="served-order-summary", methods={"GET"})
+     */
+    public function servedOrderSummary(Request $request, string $orderId)
+    {
+        $order = $this->em->getRepository(Order::class)->find($orderId);
+
+        if (!$order->getServedAt()) {
+            return $this->redirectToRoute('order-summary', ['orderId' => $orderId]);
+        }
+
+        return $this->render(
+            'Order/summary-served.html.twig',
+            ['order' => $order, ]
+        );
+    }
 }

--- a/serve-web/templates/Case/index.html.twig
+++ b/serve-web/templates/Case/index.html.twig
@@ -63,7 +63,7 @@
                             <tr class="govuk-table__row behat-region-order-{{ client.caseNumber }}-{{ order.type }}" >
                                 <td class="govuk-table__cell">
                                     {% if order.servedAt %}
-                                        <a href="{{ path('order-summary', {'orderId': order.id}) }}" id="order-{{ client.caseNumber }}-{{ order.type }}-served">
+                                        <a href="{{ path('served-order-summary', {'orderId': order.id}) }}" id="order-{{ client.caseNumber }}-{{ order.type }}-served">
                                             {{ client.caseNumber }}
                                         </a>
                                     {% else %}

--- a/serve-web/templates/Order/summary-served.html.twig
+++ b/serve-web/templates/Order/summary-served.html.twig
@@ -1,0 +1,86 @@
+{% extends 'base.html.twig' %}
+
+{% block htmlTitle %}{{ order.client.caseNumber }} order summary{% endblock %}
+
+{% block pageTitle %}
+    <span class="govuk-caption-l">Case number:{{ order.client.caseNumber }}</span>
+    <h1 class="govuk-heading-l">Order summary</h1>
+{% endblock %}
+
+{% block javascripts %}
+    {{ parent() }}
+{% endblock %}
+
+{% block content %}
+    <div class="govuk-grid-row">
+        <div class="govuk-grid-column-one-third">
+            <p class="govuk-body govuk-!-font-weight-bold govuk-!-margin-bottom-1">Client name:</p>
+            <p class="govuk-body govuk-!-font-weight-bold govuk-!-margin-bottom-1">Court order number:</p>
+            <p class="govuk-body govuk-!-font-weight-bold govuk-!-margin-bottom-1">Order served:</p>
+            <p class="govuk-body govuk-!-font-weight-bold govuk-!-margin-bottom-1">Order type:</p>
+        </div>
+        <div class="govuk-grid-column-two-thirds">
+            <p class="govuk-body govuk-!-margin-bottom-1">{{ order.client.clientName }}</p>
+            <p class="govuk-body govuk-!-margin-bottom-1">{{ order.client.caseNumber }}</p>
+            <p class="govuk-body govuk-!-margin-bottom-1">{{ order.servedAt | date('j M Y') }}</p>
+            <p class="govuk-body govuk-!-margin-bottom-1">{{ order.type }}</p>
+        </div>
+    </div>
+
+    <div class="govuk-grid-row">
+        <div class="govuk-grid-column-full">
+            <dl class="govuk-summary-list">
+                <div class="govuk-summary-list__row">
+                    <dt class="govuk-summary-list__key">
+                        Client address:
+                    </dt>
+                    <dd class="govuk-summary-list__value">
+                        TO BE ADDED LATER - WE DON'T CURRENTLY SAVE THS DATA ON CLIENT
+                    </dd>
+                    <dd class="govuk-summary-list__actions">
+                        <a class="govuk-link" href="#">
+                            Edit
+                        </a>
+                    </dd>
+                </div>
+                <div class="govuk-summary-list__row">
+                    <dt class="govuk-summary-list__key">
+                        Deputy name(s):
+                    </dt>
+                    <dd class="govuk-summary-list__value">
+                        {{ order.deputies | map(deputy => "#{deputy.fullName}") | join(', ') }}
+                    </dd>
+                    <dd class="govuk-summary-list__actions">
+                        <a class="govuk-link" href="#">
+                            Edit
+                        </a>
+                    </dd>
+                </div>
+            </dl>
+        </div>
+    </div>
+
+    <div class="govuk-grid-row">
+        <div class="govuk-grid-column-full">
+            <table class="govuk-table">
+                <caption class="govuk-table__caption govuk-table__caption--m">Documents</caption>
+                <thead class="govuk-table__head">
+                <tr class="govuk-table__row">
+                    <th scope="col" class="govuk-table__header">Name</th>
+                    <th scope="col" class="govuk-table__header">Type</th>
+                    <th scope="col" class="govuk-table__header">Date added</th>
+                </tr>
+                </thead>
+                <tbody class="govuk-table__body">
+                {% for document in order.documents %}
+                    <tr class="govuk-table__row">
+                        <th scope="row" class="govuk-table__header">{{ document.fileName }}</th>
+                        <td class="govuk-table__cell">{{ document.type }}</td>
+                        <td class="govuk-table__cell">{{ document.createdAt | date('j M Y') }}</td>
+                    </tr>
+                {% endfor %}
+                </tbody>
+            </table>
+        </div>
+    </div>
+{% endblock %}


### PR DESCRIPTION
Adds basic template for served order summary pages. Some functionality on the prototype doesn't exist yet so this feature will be revisited once its implemented.