### PR TITLE
SER-28: Stop requesting DOB for PA/Prof deputies

### DIFF
--- a/serve-web/features/05-deputy.feature
+++ b/serve-web/features/05-deputy.feature
@@ -6,37 +6,27 @@ Feature: deputy
     When I follow "order-93559316-HW"
     Then the url should match "order/\d+/summary"
     When I follow "add-deputy"
-    And the url should match "order/\d+/deputy/add"
+    And the url should match "order/\d+/deputy/add/deputy-type"
         # check form validation
     And I fill in the following:
-      | deputy_form_deputyType | LAY |
+      | deputyType | LAY |
+    And I press "deputyType_saveAndContinue"
+    And the url should match "order/\d+/deputy/add"
     And I press "deputy_form_saveAndContinue"
     Then the following fields should have an error:
       | deputy_form_forename |
       | deputy_form_surname  |
-    When I fill in the following:
-      | deputy_form_deputyType | PUBLIC_AUTHORITY |
-    And I press "deputy_form_saveAndContinue"
-    Then the response status code should be 200
-    And the following fields should have an error:
-      | deputy_form_forename         |
-      | deputy_form_surname          |
-    When I fill in the following:
-      | deputy_form_deputyType | PROFESSIONAL |
-    And I press "deputy_form_saveAndContinue"
-    Then the response status code should be 200
-    Then the following fields should have an error:
-      | deputy_form_forename         |
-      | deputy_form_surname          |
 
   Scenario: HW order: add valid deputy data
     Given I log in as "behat@digital.justice.gov.uk" with correct password
     When I go to "/case"
     When I follow "order-93559316-HW"
     When I follow "add-deputy"
-      # check form validation
+    And I fill in the following:
+      | deputyType | LAY |
+    And I press "deputyType_saveAndContinue"
+    # check form validation
     When I fill in the following:
-      | deputy_form_deputyType           | LAY                                         |
       | deputy_form_forename             | Dep                                         |
       | deputy_form_surname              | Uty                                         |
       | deputy_form_emailAddress         | behat-12345678-depy1@digital.justice.gov.uk |
@@ -68,7 +58,7 @@ Feature: deputy
     Then I follow "edit-deputy-1"
   # check form validation
     When I fill in the following:
-      | deputy_form_deputyType           | LAY                                         |
+      | deputy_form_deputyType           | PROFESSIONAL                                 |
       | deputy_form_forename             | DepE                                         |
       | deputy_form_surname              | UtyE                                          |
       | deputy_form_emailAddress         | behat-12345678-depy1E@digital.justice.gov.uk |
@@ -99,8 +89,10 @@ Feature: deputy
     When I go to "/case"
     When I follow "order-93559316-HW"
     Then I follow "add-deputy"
+    And I fill in the following:
+      | deputyType | LAY |
+    And I press "deputyType_saveAndContinue"
     When I fill in the following:
-      | deputy_form_deputyType           | LAY                                         |
       | deputy_form_forename             | Dep2                                         |
       | deputy_form_surname              | Uty2                                         |
       | deputy_form_emailAddress         | behat-12345678-depy2@digital.justice.gov.uk |
@@ -135,9 +127,11 @@ Feature: deputy
     When I go to "/case"
     When I follow "order-93559316-PF"
     When I follow "add-deputy"
+    And I fill in the following:
+      | deputyType | PUBLIC_AUTHORITY |
+    And I press "deputyType_saveAndContinue"
       # check form validation
     When I fill in the following:
-      | deputy_form_deputyType | PUBLIC_AUTHORITY |
       | deputy_form_forename   | PfPADep |
       | deputy_form_surname   | Uty |
     And I press "deputy_form_saveAndContinue"
@@ -150,9 +144,11 @@ Feature: deputy
     When I go to "/case"
     When I follow "order-93559316-HW"
     When I follow "add-deputy"
+    And I fill in the following:
+      | deputyType | PUBLIC_AUTHORITY |
+    And I press "deputyType_saveAndContinue"
   # check form validation
     When I fill in the following:
-      | deputy_form_deputyType | PUBLIC_AUTHORITY |
       | deputy_form_forename   | HwPADep |
       | deputy_form_surname   | Uty |
     And I press "deputy_form_saveAndContinue"

--- a/serve-web/src/Controller/DeputyController.php
+++ b/serve-web/src/Controller/DeputyController.php
@@ -47,13 +47,15 @@ class DeputyController extends AbstractController
     /**
      * @Route("/order/{orderId}/deputy/add", name="deputy-add")
      */
-    public function addAction(Request $request, $orderId)
+    public function add(Request $request, $orderId)
     {
         $order = $this->orderService->getOrderByIdIfNotServed($orderId);
 
         $deputy = new Deputy($order);
 
-        $form = $this->createForm(DeputyForm::class, $deputy);
+        $deputyType = !empty($request->get('deputyType')) ? $request->get('deputyType') : null;
+
+        $form = $this->createForm(DeputyForm::class, $deputy, ['deputyType' => $deputyType]);
         $form->handleRequest($request);
 
         $buttonClicked = $form->getClickedButton();
@@ -73,7 +75,20 @@ class DeputyController extends AbstractController
         return $this->render('Deputy/add.html.twig', [
             'client' => $order->getClient(),
             'order' => $order,
-            'form' => $form->createView()
+            'form' => $form->createView(),
+            'deputyType' => $deputyType
+        ]);
+    }
+
+    /**
+     * @Route("/order/{orderId}/deputy/add/deputy-type", name="deputy-type")
+     */
+    public function chooseDeputyType(Request $request, $orderId)
+    {
+        $order = $this->orderService->getOrderByIdIfNotServed($orderId);
+
+        return $this->render('Deputy/type.html.twig', [
+            'order' => $order,
         ]);
     }
 
@@ -85,7 +100,7 @@ class DeputyController extends AbstractController
      *
      * @return \Symfony\Component\HttpFoundation\RedirectResponse|Response
      */
-    public function editAction(Request $request, $orderId, $deputyId)
+    public function edit(Request $request, $orderId, $deputyId)
     {
         $order = $this->em->getRepository(Order::class)->find($orderId);
 
@@ -95,7 +110,7 @@ class DeputyController extends AbstractController
             throw new \RuntimeException('Unknown Deputy');
         }
 
-        $form = $this->createForm(DeputyForm::class, $deputy);
+        $form = $this->createForm(DeputyForm::class, $deputy, ['deputyType' => $deputy->getDeputyType()]);
         $form->handleRequest($request);
 
         if ($form->isSubmitted() && $form->isValid()) {
@@ -108,7 +123,8 @@ class DeputyController extends AbstractController
         return $this->render('Deputy/add.html.twig', [
             'client' => $order->getClient(),
             'order' => $order,
-            'form' => $form->createView()
+            'form' => $form->createView(),
+            'deputyType' => $deputy->getDeputyType()
         ]);
     }
 
@@ -120,7 +136,7 @@ class DeputyController extends AbstractController
      *
      * @return \Symfony\Component\HttpFoundation\RedirectResponse|Response
      */
-    public function deleteAction(Request $request, $orderId, $deputyId)
+    public function delete(Request $request, $orderId, $deputyId)
     {
         $order = $this->em->getRepository(Order::class)->find($orderId);
 

--- a/serve-web/src/Form/DeputyForm.php
+++ b/serve-web/src/Form/DeputyForm.php
@@ -31,7 +31,8 @@ class DeputyForm extends AbstractType
                     'deputy.type.LAY' => Deputy::DEPUTY_TYPE_LAY,
                     'deputy.type.PUBLIC_AUTHORITY' => Deputy::DEPUTY_TYPE_PA,
                     'deputy.type.PROFESSIONAL' => Deputy::DEPUTY_TYPE_PROF
-                ]
+                ],
+                'data' => $deputyTypeValue
             ])
             ->add('forename', TextType::class, [
                 'label' => 'deputy.forename',

--- a/serve-web/src/Form/DeputyForm.php
+++ b/serve-web/src/Form/DeputyForm.php
@@ -8,6 +8,7 @@ use App\Entity\Post;
 use App\Common\Form\Answers;
 use Symfony\Component\Form\AbstractType;
 use Symfony\Component\Form\Extension\Core\Type\ChoiceType;
+use Symfony\Component\Form\Extension\Core\Type\HiddenType;
 use Symfony\Component\Form\Extension\Core\Type\SubmitType;
 use Symfony\Component\Form\Extension\Core\Type\TextType;
 use Symfony\Component\Form\Extension\Core\Type\BirthdayType;
@@ -19,10 +20,12 @@ class DeputyForm extends AbstractType
 {
     public function buildForm(FormBuilderInterface $builder, array $options)
     {
+        $deputyTypeValue = !empty($options['deputyType']) ? $options['deputyType'] : '';
+
         $builder
             ->add('deputyType', ChoiceType::class, [
                 'label' => 'deputy.type.label',
-                'required' => false,
+                'required' => true,
                 'choices' => [
                     'deputy.type.pleaseSelect' => '',
                     'deputy.type.LAY' => Deputy::DEPUTY_TYPE_LAY,
@@ -39,15 +42,6 @@ class DeputyForm extends AbstractType
                 'label' => 'deputy.surname',
                 'required' => false,
                 'attr' => ['maxlength'=> 255]
-            ])
-            ->add('dateOfBirth', BirthdayType::class, [
-                'label' => 'deputy.dateOfBirth.label',
-                'required' => true,
-                'widget' => 'text',
-                'placeholder' => array(
-                    'day' => 'Day','month' => 'Month' , 'year' => 'Year'
-                ),
-                'format' => 'dd-MM-yyyy',
             ])
             ->add('emailAddress', TextType::class, [
                 'label' => 'deputy.emailAddress.label',
@@ -97,6 +91,18 @@ class DeputyForm extends AbstractType
                 'attr' => ['maxlength'=> 255]
             ])
             ->add('saveAndContinue', SubmitType::class);
+
+        if ($deputyTypeValue === 'LAY') {
+            $builder->add('dateOfBirth', BirthdayType::class, [
+                'label' => 'deputy.dateOfBirth.label',
+                'required' => true,
+                'widget' => 'text',
+                'placeholder' => array(
+                    'day' => 'Day','month' => 'Month' , 'year' => 'Year'
+                ),
+                'format' => 'dd-MM-yyyy',
+            ]);
+        }
     }
 
     public function configureOptions(OptionsResolver $resolver)
@@ -115,7 +121,8 @@ class DeputyForm extends AbstractType
                 }
 
                 return $validationGroups;
-            }
+            },
+            'deputyType' => ''
         ));
     }
 }

--- a/serve-web/templates/Deputy/add.html.twig
+++ b/serve-web/templates/Deputy/add.html.twig
@@ -55,9 +55,10 @@
 
                 {{ form_row(form.emailAddress) }}
 
-                <h2 class="govuk-heading-m">Date of birth</h2>
-
-                {{ form_row(form.dateOfBirth) }}
+                {% if deputyType == 'LAY' %}
+                    <h2 class="govuk-heading-m">Date of birth</h2>
+                    {{ form_row(form.dateOfBirth) }}
+                {% endif %}
 
                 {{ form_widget(form.saveAndContinue) }}
                 <a href="{{ path('order-summary', {'orderId': order.id}) }}" class="govuk-link govuk-!-margin-left-3 govuk-!-padding-top-2 govuk-link--button">Cancel</a>

--- a/serve-web/templates/Deputy/type.html.twig
+++ b/serve-web/templates/Deputy/type.html.twig
@@ -26,7 +26,7 @@
                     </select>
                 </div>
 
-                <button type="submit" class="govuk-button" data-module="govuk-button">Save and continue</button>
+                <button type="submit" class="govuk-button" data-module="govuk-button" id="deputyType_saveAndContinue">Save and continue</button>
             </form>
         </div>
     </div>

--- a/serve-web/templates/Deputy/type.html.twig
+++ b/serve-web/templates/Deputy/type.html.twig
@@ -1,0 +1,33 @@
+{% extends 'base.html.twig' %}
+{% import 'Macros/_macros.html.twig' as macro %}
+
+{% block htmlTitle %}{{ ('order.' ~ order.type) | trans }} deputy details{% endblock %}
+{% block pageTitle %}
+    <span class="govuk-caption-l">{{ order.client.caseNumber }} {{ order.client.clientName }}</span>
+    <h1 class="govuk-heading-l">{{ ('order.' ~ order.type) | trans }}: deputy details</h1>
+{% endblock %}
+
+{% block javascripts %}
+    {{ parent('app') }}
+{% endblock %}
+
+{% block content %}
+    <div class="govuk-grid-row">
+        <div class="govuk-grid-column-two-thirds">
+            <form class="form-group" action="{{ path('deputy-add', {'orderId': order.id}) }}" method="get">
+                <div class="govuk-form-group">
+                    <label class="govuk-label" for="deputyType">
+                        {{ 'deputy.type.pleaseSelect' | trans({}, 'forms') }}
+                    </label>
+                    <select class="govuk-select" id="deputyType" name="deputyType">
+                        <option selected="" value="LAY">Lay</option>
+                        <option value="PUBLIC_AUTHORITY">Public authority</option>
+                        <option value="PROFESSIONAL">Professional</option>
+                    </select>
+                </div>
+
+                <button type="submit" class="govuk-button" data-module="govuk-button">Save and continue</button>
+            </form>
+        </div>
+    </div>
+{% endblock %}

--- a/serve-web/templates/Order/summary.html.twig
+++ b/serve-web/templates/Order/summary.html.twig
@@ -137,7 +137,7 @@
     {% endif %}
 
     <p>
-        <a href="{{ path('deputy-add', {'orderId': order.id}) }}" id="add-deputy" class=" govuk-link govuk-!-font-weight-bold">
+        <a href="{{ path('deputy-type', {'orderId': order.id}) }}" id="add-deputy" class=" govuk-link govuk-!-font-weight-bold">
             <span class="govuk-icon govuk-icon--plus"></span>Add a deputy
         </a>
     </p>

--- a/serve-web/tests/Form/DeputyFormTest.php
+++ b/serve-web/tests/Form/DeputyFormTest.php
@@ -27,8 +27,8 @@ class DeputyFormTest extends TypeTestCase
         ];
 
         $model = new Deputy(OrderTestHelper::generateOrder('2016-01-01', '2016-01-02', '16472847', 'HW', $timeNow->format('Y-m-d')));
-
-        $form = $this->factory->create(DeputyForm::class, $model);
+        
+        $form = $this->factory->create(DeputyForm::class, $model, ['deputyType' => 'LAY']);
 
         $expected = new Deputy(OrderTestHelper::generateOrder('2016-01-01', '2016-01-02', '16472847', 'HW', $timeNow->format('Y-m-d')));
         $expected->setDeputyType('LAY');

--- a/serve-web/translations/forms.en.yml
+++ b/serve-web/translations/forms.en.yml
@@ -1,7 +1,7 @@
 deputy:
   type:
     label: Deputy type
-    pleaseSelect: Please select
+    pleaseSelect: Please select a deputy type
     LAY: 'Lay'
     PUBLIC_AUTHORITY: 'Public authority'
     PROFESSIONAL: 'Professional'


### PR DESCRIPTION
This was a little more involved than expected as the deputy type is defined on the same page that we request DOB. Rather than rely on JS I've broken the deputy type question out to a new page that appears before the deputy details screen so we have that value ready to alter the fields in the form before its rendered:

![Screenshot 2021-09-09 at 17 45 56](https://user-images.githubusercontent.com/17926619/132728101-97a9dd69-ef04-4a98-b355-95423a43c1e7.png)
