### PR TITLE
Bump localstack

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -33,8 +33,8 @@ orbs:
                 docker-compose up -d localstack
 
                 docker-compose run --rm waitforit -address=http://localstack:4572 -debug -timeout=30
-                docker-compose run --rm aws --endpoint-url=http://localstack:4572 s3 mb s3://sirius_test_bucket
-                docker-compose run --rm aws --endpoint-url=http://localstack:4572 s3 mb s3://test_bucket
+                docker-compose run --rm aws --endpoint-url=http://localstack:4572 s3 mb s3://sirius
+                docker-compose run --rm aws --endpoint-url=http://localstack:4572 s3 mb s3://test
 
                 # Create dynamodb tables
                 docker-compose run --rm aws --region eu-west-1 --endpoint-url=http://localstack:4569 dynamodb create-table --cli-input-json file://attempts_table.json

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -33,8 +33,8 @@ orbs:
                 docker-compose up -d localstack
 
                 docker-compose run --rm waitforit -address=http://localstack:4572 -debug -timeout=30
-                docker-compose run --rm aws --endpoint-url=http://localstack:4572 s3 mb s3://sirius
-                docker-compose run --rm aws --endpoint-url=http://localstack:4572 s3 mb s3://test
+                docker-compose run --rm aws --endpoint-url=http://localstack:4572 s3 mb s3://sirius-test-bucket
+                docker-compose run --rm aws --endpoint-url=http://localstack:4572 s3 mb s3://test-bucket
 
                 # Create dynamodb tables
                 docker-compose run --rm aws --region eu-west-1 --endpoint-url=http://localstack:4569 dynamodb create-table --cli-input-json file://attempts_table.json

--- a/.env
+++ b/.env
@@ -31,7 +31,7 @@ DC_DB_USER=serve-opg
 # Google tag manager
 DC_GTM=null
 
-DC_S3_BUCKET_NAME=test
+DC_S3_BUCKET_NAME=test-bucket
 DC_S3_ENDPOINT=http://localstack:4572
 DC_S3_REGION=eu-west-1
 DC_SIRIUS_URL=http://sirius-api:4010/
@@ -40,6 +40,6 @@ INFRA_VERSION=0-local-infra
 # Sirius
 SIRIUS_KMS_KEY_ARN=arn:aws:kms:eu-west-1:012345678901:alias/notification_api_key
 SIRIUS_PUBLIC_API_EMAIL=fake@email.address
-SIRIUS_S3_BUCKET_NAME=sirius
+SIRIUS_S3_BUCKET_NAME=sirius-test-bucket
 
 WEB_VERSION=0-local-web

--- a/.env
+++ b/.env
@@ -31,7 +31,7 @@ DC_DB_USER=serve-opg
 # Google tag manager
 DC_GTM=null
 
-DC_S3_BUCKET_NAME=test_bucket
+DC_S3_BUCKET_NAME=test
 DC_S3_ENDPOINT=http://localstack:4572
 DC_S3_REGION=eu-west-1
 DC_SIRIUS_URL=http://sirius-api:4010/
@@ -40,6 +40,6 @@ INFRA_VERSION=0-local-infra
 # Sirius
 SIRIUS_KMS_KEY_ARN=arn:aws:kms:eu-west-1:012345678901:alias/notification_api_key
 SIRIUS_PUBLIC_API_EMAIL=fake@email.address
-SIRIUS_S3_BUCKET_NAME=sirius_test_bucket
+SIRIUS_S3_BUCKET_NAME=sirius
 
 WEB_VERSION=0-local-web

--- a/Makefile
+++ b/Makefile
@@ -55,8 +55,8 @@ build-deps: ## Runs through all steps required before the app can be brought up
 	# & wait for the server to become available
 	docker-compose up -d localstack
 	docker-compose run --rm waitforit -address=http://localstack:4572 -debug -timeout=30
-	docker-compose run --rm aws --endpoint-url=http://localstack:4572 s3 mb s3://sirius_test_bucket
-	docker-compose run --rm aws --endpoint-url=http://localstack:4572 s3 mb s3://test_bucket
+	docker-compose run --rm aws --endpoint-url=http://localstack:4572 s3 mb s3://sirius
+	docker-compose run --rm aws --endpoint-url=http://localstack:4572 s3 mb s3://test
 
 	# Create dynamodb tables (using - before command allows errors. Required as the table could already exist)
 	@-docker-compose run --rm aws --region eu-west-1 --endpoint-url=http://localstack:4569 dynamodb create-table --cli-input-json file://attempts_table.json

--- a/Makefile
+++ b/Makefile
@@ -55,8 +55,8 @@ build-deps: ## Runs through all steps required before the app can be brought up
 	# & wait for the server to become available
 	docker-compose up -d localstack
 	docker-compose run --rm waitforit -address=http://localstack:4572 -debug -timeout=30
-	docker-compose run --rm aws --endpoint-url=http://localstack:4572 s3 mb s3://sirius
-	docker-compose run --rm aws --endpoint-url=http://localstack:4572 s3 mb s3://test
+	docker-compose run --rm aws --endpoint-url=http://localstack:4572 s3 mb s3://sirius-test-bucket
+	docker-compose run --rm aws --endpoint-url=http://localstack:4572 s3 mb s3://test-bucket
 
 	# Create dynamodb tables (using - before command allows errors. Required as the table could already exist)
 	@-docker-compose run --rm aws --region eu-west-1 --endpoint-url=http://localstack:4569 dynamodb create-table --cli-input-json file://attempts_table.json

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -88,11 +88,14 @@ services:
       - --dynamic
 
   localstack:
-    image: localstack/localstack:0.9.1
+    image: localstack/localstack:0.10.9
     environment:
       - SERVICES=s3:4572,dynamodb:4569
       - DATA_DIR=/tmp/localstack/data
       - DEFAULT_REGION=eu-west-1
+    ports:
+      - "4572:4572"
+      - "4569:4569"
     volumes:
       - ./serve-web/localstack-data:/tmp/localstack/data
 

--- a/serve-web/.env
+++ b/serve-web/.env
@@ -31,7 +31,7 @@ DC_DB_USER=serve-opg
 # Google tag manager
 DC_GTM=null
 
-DC_S3_BUCKET_NAME=test
+DC_S3_BUCKET_NAME=test-bucket
 DC_S3_ENDPOINT=http://localstack:4572
 DC_S3_REGION=eu-west-1
 DC_SIRIUS_URL=http://sirius-api:4010/
@@ -40,6 +40,6 @@ INFRA_VERSION=0-local-infra
 # Sirius
 SIRIUS_KMS_KEY_ARN=arn:aws:kms:eu-west-1:012345678901:alias/notification_api_key
 SIRIUS_PUBLIC_API_EMAIL=fake@email.address
-SIRIUS_S3_BUCKET_NAME=sirius
+SIRIUS_S3_BUCKET_NAME=sirius-test-bucket
 
 WEB_VERSION=0-local-web

--- a/serve-web/.env
+++ b/serve-web/.env
@@ -31,7 +31,7 @@ DC_DB_USER=serve-opg
 # Google tag manager
 DC_GTM=null
 
-DC_S3_BUCKET_NAME=test_bucket
+DC_S3_BUCKET_NAME=test
 DC_S3_ENDPOINT=http://localstack:4572
 DC_S3_REGION=eu-west-1
 DC_SIRIUS_URL=http://sirius-api:4010/
@@ -40,6 +40,6 @@ INFRA_VERSION=0-local-infra
 # Sirius
 SIRIUS_KMS_KEY_ARN=arn:aws:kms:eu-west-1:012345678901:alias/notification_api_key
 SIRIUS_PUBLIC_API_EMAIL=fake@email.address
-SIRIUS_S3_BUCKET_NAME=sirius_test_bucket
+SIRIUS_S3_BUCKET_NAME=sirius
 
 WEB_VERSION=0-local-web

--- a/serve-web/README.md
+++ b/serve-web/README.md
@@ -40,8 +40,8 @@ sudo security add-trusted-cert -d -r trustRoot \
 # & wait for the server to become available
 docker-compose up -d localstack
 docker-compose run --rm waitforit -address=http://localstack:4572 -debug -timeout=30
-docker-compose run --rm aws --endpoint-url=http://localstack:4572 s3 mb s3://sirius_test_bucket
-docker-compose run --rm aws --endpoint-url=http://localstack:4572 s3 mb s3://test_bucket
+docker-compose run --rm aws --endpoint-url=http://localstack:4572 s3 mb s3://sirius
+docker-compose run --rm aws --endpoint-url=http://localstack:4572 s3 mb s3://test
 
 # Create dynamodb tables
 docker-compose run --rm aws --region eu-west-1 --endpoint-url=http://localstack:4569 dynamodb create-table --cli-input-json file://attempts_table.json

--- a/serve-web/README.md
+++ b/serve-web/README.md
@@ -40,8 +40,8 @@ sudo security add-trusted-cert -d -r trustRoot \
 # & wait for the server to become available
 docker-compose up -d localstack
 docker-compose run --rm waitforit -address=http://localstack:4572 -debug -timeout=30
-docker-compose run --rm aws --endpoint-url=http://localstack:4572 s3 mb s3://sirius
-docker-compose run --rm aws --endpoint-url=http://localstack:4572 s3 mb s3://test
+docker-compose run --rm aws --endpoint-url=http://localstack:4572 s3 mb s3://sirius-test-bucket
+docker-compose run --rm aws --endpoint-url=http://localstack:4572 s3 mb s3://test-bucket
 
 # Create dynamodb tables
 docker-compose run --rm aws --region eu-west-1 --endpoint-url=http://localstack:4569 dynamodb create-table --cli-input-json file://attempts_table.json

--- a/serve-web/src/Service/S3Client.php
+++ b/serve-web/src/Service/S3Client.php
@@ -23,6 +23,7 @@ class S3Client extends \Aws\S3\S3Client
         // custom endpoint e.g. fakes3
         if ($s3Endpoint) {
             $args += [
+                'use_path_style_endpoint' => true,
                 'endpoint' => $s3Endpoint,
                 'validate' => false
             ];


### PR DESCRIPTION
The version of localstack we were using included an old version of pip based on python 2.7 which is unsupported and blocking our release pipeline in serve-opg-infrastructure. This bumps the version up to ensure we're using a supported version of python (3.8).

There were some changes to the default behaviour of localstack during the upgrade:

- Bucket names no longer allow underscores
- By default, bucket names are prepended to bucket URLs

Due to these changes I've updated the bucket name and set the default bucket URL to be path based rather than domain/bucket name-based.