### PR TITLE
Bump circleci/docker orb

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -3,7 +3,7 @@ version: 2.1
 orbs:
   dockerhub_helper:
     orbs:
-      docker: circleci/docker@1.4.0
+      docker: circleci/docker@1.7.0
     commands:
       dockerhub_login:
         steps:


### PR DESCRIPTION
Seeing some weirdness in [CircleCI](https://app.circleci.com/pipelines/github/ministryofjustice/serve-opg/2025/workflows/123a7948-f71c-41d5-baa9-5abbddc7e23b/jobs/2366) when trying to run `docker/install-docker-credential-helper` so seeing if an up to date version does the trick.