### PR TITLE
Update ecr login as get-login is deprecated in favour of get-login-pa…

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -75,7 +75,7 @@ services:
       - ./serve-web/var:/www/var/
 
   sirius-api:
-    image: stoplight/prism:latest
+    image: stoplight/prism:4.4.1
     ports:
       - 4010:4010
     volumes:

--- a/serve-web/docker_login.sh
+++ b/serve-web/docker_login.sh
@@ -7,4 +7,9 @@ export AWS_ACCESS_KEY_ID=$(echo $temp_role | jq .Credentials.AccessKeyId | xargs
 export AWS_SECRET_ACCESS_KEY=$(echo $temp_role | jq .Credentials.SecretAccessKey | xargs)
 export AWS_SESSION_TOKEN=$(echo $temp_role | jq .Credentials.SessionToken | xargs)
 
-eval $(aws ecr get-login --no-include-email --region=eu-west-1)
+aws ecr get-login-password \
+    --region eu-west-1 \
+| docker login \
+    --username AWS \
+    --password-stdin 311462405659.dkr.ecr.eu-west-1.amazonaws.com
+


### PR DESCRIPTION
The AWS cli was updated in the circle orb images we used which has led to some of the deploy script using deprecated commands. From the docs this looks to be the new way of logging into ECR but its a little hard to tell until we deploy.