### PR TITLE
Switch to node 16 alpine

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -97,8 +97,6 @@ jobs:
       - store_test_results:
           path: ./serve-web/tests/artifacts
       - store_artifacts:
-          path: /tmp/behat
-      - store_artifacts:
           path: ./serve-web/tests/artifacts
 
   build:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -95,11 +95,11 @@ jobs:
       - test/unit
       - test/integration
       - store_test_results:
-          path: ./tests/artifacts
+          path: ./serve-web/tests/artifacts
       - store_artifacts:
           path: /tmp/behat
       - store_artifacts:
-          path: ./tests/artifacts
+          path: ./serve-web/tests/artifacts
 
   build:
     machine:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -110,7 +110,7 @@ services:
       POSTGRES_PASSWORD: dcdb2018!
 
   yarn:
-    image: node:14.17-stretch
+    image: node:16-alpine
     environment:
       PATH: /node_modules/.bin:$PATH
     working_dir: /var/www

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -75,7 +75,7 @@ services:
       - ./serve-web/var:/www/var/
 
   sirius-api:
-    image: stoplight/prism:latest
+    image: stoplight/prism:4.4.1
     ports:
       - 4010:4010
     volumes:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -123,7 +123,7 @@ services:
     image: php:7.4-fpm-alpine
     volumes:
       - ./serve-web:/var/www
-      - ./serve-web/features/screenshots:/tmp/behat
+      - ./serve-web/tests/artifacts/behat/screenshots:/tmp/behat
     working_dir: /var/www
     entrypoint:
       - vendor/bin/behat


### PR DESCRIPTION
- Use a smaller and more up to date Docker container for node.
- Pin Prism to fix mocks
- Update test and artefact locations