### PR TITLE
Trigger infra builds

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -160,7 +160,7 @@ jobs:
           docker tag $ECR_REGISTRY/serve-opg/app:latest $ECR_REGISTRY/serve-opg/app:${{ steps.bump_version.outputs.tag }}
           docker tag $ECR_REGISTRY/serve-opg/web:latest $ECR_REGISTRY/serve-opg/web:${{ steps.bump_version.outputs.tag }}
           docker tag $ECR_REGISTRY/serve-opg/api:latest $ECR_REGISTRY/serve-opg/api:${{ steps.bump_version.outputs.tag }}
-          if [ "$BRANCH_NAME" == "main" ]; then
+          if [ "$BRANCH_NAME" == "master" ]; then
             # We want all of the tags pushed
             docker tag $ECR_REGISTRY/serve-opg/app:latest $ECR_REGISTRY/serve-opg/app:main-${{ steps.bump_version.outputs.tag }}
             docker tag $ECR_REGISTRY/serve-opg/web:latest $ECR_REGISTRY/serve-opg/web:main-${{ steps.bump_version.outputs.tag }}
@@ -168,6 +168,7 @@ jobs:
             docker push --all-tags $ECR_REGISTRY/serve-opg/app
             docker push --all-tags $ECR_REGISTRY/serve-opg/web
             docker push --all-tags $ECR_REGISTRY/serve-opg/api
+            curl --silent --show-error --fail -X POST "https://circleci.com/api/v1.1/project/github/ministryofjustice/serve-opg-infrastructure/build?circle-token=${secrets.CIRCLE_API_KEY}"
           else
             docker push $ECR_REGISTRY/serve-opg/app:${{ steps.bump_version.outputs.tag }}
             docker push $ECR_REGISTRY/serve-opg/web:${{ steps.bump_version.outputs.tag }}

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -177,6 +177,7 @@ jobs:
       - name: Trigger infra deploy
         uses: actions/github-script@v5
         with:
+          github-token: ${{ secrets.MY_PAT }}
           script: |
 #            How to add auth?
             await github.rest.actions.createWorkflowDispatch({

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -160,29 +160,11 @@ jobs:
           docker tag $ECR_REGISTRY/serve-opg/app:latest $ECR_REGISTRY/serve-opg/app:${{ steps.bump_version.outputs.tag }}
           docker tag $ECR_REGISTRY/serve-opg/web:latest $ECR_REGISTRY/serve-opg/web:${{ steps.bump_version.outputs.tag }}
           docker tag $ECR_REGISTRY/serve-opg/api:latest $ECR_REGISTRY/serve-opg/api:${{ steps.bump_version.outputs.tag }}
-          if [ "$BRANCH_NAME" == "master" ]; then
-            # We want all of the tags pushed
-            docker tag $ECR_REGISTRY/serve-opg/app:latest $ECR_REGISTRY/serve-opg/app:master-${{ steps.bump_version.outputs.tag }}
-            docker tag $ECR_REGISTRY/serve-opg/web:latest $ECR_REGISTRY/serve-opg/web:master-${{ steps.bump_version.outputs.tag }}
-            docker tag $ECR_REGISTRY/serve-opg/api:latest $ECR_REGISTRY/serve-opg/api:master-${{ steps.bump_version.outputs.tag }}
-            docker push --all-tags $ECR_REGISTRY/serve-opg/app
-            docker push --all-tags $ECR_REGISTRY/serve-opg/web
-            docker push --all-tags $ECR_REGISTRY/serve-opg/api
-          else
-            docker push $ECR_REGISTRY/serve-opg/app:${{ steps.bump_version.outputs.tag }}
-            docker push $ECR_REGISTRY/serve-opg/web:${{ steps.bump_version.outputs.tag }}
-            docker push $ECR_REGISTRY/serve-opg/api:${{ steps.bump_version.outputs.tag }}
+          docker push $ECR_REGISTRY/serve-opg/app:${{ steps.bump_version.outputs.tag }}
+          docker push $ECR_REGISTRY/serve-opg/web:${{ steps.bump_version.outputs.tag }}
+          docker push $ECR_REGISTRY/serve-opg/api:${{ steps.bump_version.outputs.tag }}
           fi
 
       - name: Trigger infra deploy
-        uses: actions/github-script@v5
-        with:
-#          Temp set to api token registered against acsauk user - due to expire in 30 days, find long term solution
-          github-token: ${{ secrets.GH_API_TOKEN }}
-          script: |
-            await github.rest.actions.createWorkflowDispatch({
-              context.repo.owner,
-              'serve-opg-infrastructure',
-              'deploy.yml',
-              'master',
-            });
+        run: |
+          curl --silent --show-error --fail -X POST "https://circleci.com/api/v1.1/project/github/ministryofjustice/serve-opg-infrastructure/build?circle-token=${{ secrets.CIRCLE_API_KEY }}"

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -177,9 +177,9 @@ jobs:
       - name: Trigger infra deploy
         uses: actions/github-script@v5
         with:
-          github-token: ${{ secrets.MY_PAT }}
+#          Temp set to api token registered against acsauk user - due to expire in 30 days, find long term solution
+          github-token: ${{ secrets.GH_API_TOKEN }}
           script: |
-#            How to add auth?
             await github.rest.actions.createWorkflowDispatch({
               context.repo.owner,
               'serve-opg-infrastructure',

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -106,7 +106,7 @@ jobs:
       - name: Extract branch name
         run: |
           if [ "${{ github.head_ref }}" == "" ]; then
-            echo BRANCH_NAME=main >> $GITHUB_ENV
+            echo BRANCH_NAME=master >> $GITHUB_ENV
           else
             echo BRANCH_NAME=${{ github.head_ref }} >> $GITHUB_ENV
           fi

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -168,9 +168,20 @@ jobs:
             docker push --all-tags $ECR_REGISTRY/serve-opg/app
             docker push --all-tags $ECR_REGISTRY/serve-opg/web
             docker push --all-tags $ECR_REGISTRY/serve-opg/api
-            curl --silent --show-error --fail -X POST "https://circleci.com/api/v1.1/project/github/ministryofjustice/serve-opg-infrastructure/build?circle-token=${secrets.CIRCLE_API_KEY}"
           else
             docker push $ECR_REGISTRY/serve-opg/app:${{ steps.bump_version.outputs.tag }}
             docker push $ECR_REGISTRY/serve-opg/web:${{ steps.bump_version.outputs.tag }}
             docker push $ECR_REGISTRY/serve-opg/api:${{ steps.bump_version.outputs.tag }}
           fi
+
+      - name: Trigger infra deploy
+        uses: actions/github-script@v5
+        with:
+          script: |
+#            How to add auth?
+            await github.rest.actions.createWorkflowDispatch({
+              context.repo.owner,
+              'serve-opg-infrastructure',
+              'deploy.yml',
+              'master',
+            });

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -162,9 +162,9 @@ jobs:
           docker tag $ECR_REGISTRY/serve-opg/api:latest $ECR_REGISTRY/serve-opg/api:${{ steps.bump_version.outputs.tag }}
           if [ "$BRANCH_NAME" == "master" ]; then
             # We want all of the tags pushed
-            docker tag $ECR_REGISTRY/serve-opg/app:latest $ECR_REGISTRY/serve-opg/app:main-${{ steps.bump_version.outputs.tag }}
-            docker tag $ECR_REGISTRY/serve-opg/web:latest $ECR_REGISTRY/serve-opg/web:main-${{ steps.bump_version.outputs.tag }}
-            docker tag $ECR_REGISTRY/serve-opg/api:latest $ECR_REGISTRY/serve-opg/api:main-${{ steps.bump_version.outputs.tag }}
+            docker tag $ECR_REGISTRY/serve-opg/app:latest $ECR_REGISTRY/serve-opg/app:master-${{ steps.bump_version.outputs.tag }}
+            docker tag $ECR_REGISTRY/serve-opg/web:latest $ECR_REGISTRY/serve-opg/web:master-${{ steps.bump_version.outputs.tag }}
+            docker tag $ECR_REGISTRY/serve-opg/api:latest $ECR_REGISTRY/serve-opg/api:master-${{ steps.bump_version.outputs.tag }}
             docker push --all-tags $ECR_REGISTRY/serve-opg/app
             docker push --all-tags $ECR_REGISTRY/serve-opg/web
             docker push --all-tags $ECR_REGISTRY/serve-opg/api


### PR DESCRIPTION
During the move to GitHub actions the step to manually trigger a Circle CI build was dropped. This reinstates the callout and fixes incorrect references to a (currently) non-existent `main` branch.