### PR TITLE
Reset behat fixtures inside tests

### DIFF
--- a/serve-web/features/00-init.feature
+++ b/serve-web/features/00-init.feature
@@ -1,5 +1,9 @@
 Feature: prechecks
 
+    Scenario: Reset database
+        When I go to "/behat/reset-database"
+        Then the response status code should be 200
+
     Scenario: Reset behat users
         When I go to "/behat/reset-behat-test-users"
         Then the response status code should be 200


### PR DESCRIPTION
In preprod the test database contains data from the development test run. This wasn't an issue prior to load testing 2499 row CSV uploads but now this breaks existing tests due to items being expected on the page. This ensures we start with a fresh database at the start of each test run.

Longer-term we want tests to be in isolation so this is a stop-gap measure for now.