### PR TITLE
SER-115: Drop unique constraint on Order::order number

### DIFF
--- a/serve-web/src/Migrations/Version20220111133347.php
+++ b/serve-web/src/Migrations/Version20220111133347.php
@@ -1,0 +1,29 @@
+<?php
+
+declare(strict_types=1);
+
+namespace DoctrineMigrations;
+
+use Doctrine\DBAL\Schema\Schema;
+use Doctrine\Migrations\AbstractMigration;
+
+final class Version20220111133347 extends AbstractMigration
+{
+    public function getDescription() : string
+    {
+        return 'Dropping the unique index on order_number to account for rare occasions where we get a duplicate order number';
+    }
+
+    public function up(Schema $schema) : void
+    {
+        $this->addSql('DROP INDEX UNIQ_450EF9F7551F0F81');
+
+    }
+
+    public function down(Schema $schema) : void
+    {
+        $this->abortIf($this->connection->getDatabasePlatform()->getName() !== 'postgresql', 'Migration can only be executed safely on \'postgresql\'.');
+
+        $this->addSql('CREATE UNIQUE INDEX UNIQ_450EF9F7551F0F81 ON dc_order (order_number)');
+    }
+}


### PR DESCRIPTION
## Description
We originally added a unique constraint against `Order::OrderNumber` as we expected this to always be a unique value. We've since encountered what looks like a cleanup of an incorrectly typed order that has resulted in a duplicate order number. Rather than trying to update existing orders we should allow duplicate order numbers - mainly because this would be masking the issue of our ever-growing order list. Longer term we need a way to remove or flag orders once they have dropped off the CSV.

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Issues Resolved

SER-115

## Merge check List

- [ ] New functionality includes testing
- [ ] New functionality has been documented in the README if applicable
- [ ] Approved by PMs
