### PR TITLE
modified: added comments to exported functions to follow Go's effective Go handbook

### DIFF
--- a/serve-api/entity/client.go
+++ b/serve-api/entity/client.go
@@ -4,6 +4,7 @@ import (
 	"gorm.io/gorm"
 )
 
+// Client defines the information a client holds
 type Client struct {
 	gorm.Model
 	ID         uint32 `gorm:"not null;type:bigint;autoIncrement"`
@@ -12,14 +13,17 @@ type Client struct {
 	ClientName string `gorm:"size:255;not null"`
 }
 
+// CreateClient will create a client in the database with the passed in values
 func CreateClient(db *gorm.DB, case_number string, client_name string) {
 	db.Create(&Client{CaseNumber: case_number, ClientName: client_name})
 }
 
+// SelectClientByID will select a client by their ID
 func (c *Client) SelectClientByID(db *gorm.DB, id int) *gorm.DB {
 	return db.First(c, id)
 }
 
+// TableName refers to the table name used in the database
 func (client *Client) TableName() string {
 	return "client"
 }

--- a/serve-api/entity/deputy.go
+++ b/serve-api/entity/deputy.go
@@ -6,6 +6,7 @@ import (
 	"gorm.io/gorm"
 )
 
+// Deputy defines the information a deputy holds
 type Deputy struct {
 	gorm.Model
 	ID                   int     `gorm:"not null;type:bigint;autoIncrement"`
@@ -26,6 +27,7 @@ type Deputy struct {
 	AddressPostcode      string `gorm:"size:255;"`
 }
 
+// CreateDeputy will create a deputy in the database with the passed in values
 func CreateDeputy(
 	db *gorm.DB,
 	deputyType string,
@@ -61,10 +63,12 @@ func CreateDeputy(
 	})
 }
 
+// SelectDeputyByID will select a deputy by their ID
 func (d *Deputy) SelectDeputyByID(db *gorm.DB, id int) *gorm.DB {
 	return db.First(d, id)
 }
 
+// TableName refers to the table name used in the database
 func (d *Deputy) TableName() string {
 	return "deputy"
 }

--- a/serve-api/entity/document.go
+++ b/serve-api/entity/document.go
@@ -4,6 +4,7 @@ import (
 	"gorm.io/gorm"
 )
 
+// Document defines the information a document holds
 type Document struct {
 	gorm.Model
 	ID                     uint32 `gorm:"not null;type:bigint;autoIncrement"`
@@ -14,6 +15,7 @@ type Document struct {
 	RemoteStorageReference string `gorm:"size:255"`
 }
 
+// CreateDocument will create a document in the database with the passed in values
 func CreateDocument(
 	db *gorm.DB,
 	orderId uint32,
@@ -31,11 +33,13 @@ func CreateDocument(
 	})
 }
 
+// SelectDocumentByID will select a document by their ID
 func (d *Document) SelectDocumentByID(db *gorm.DB, id int) *gorm.DB {
 	var document Document
 	return db.First(&document, id)
 }
 
+// TableName refers to the table name used in the database
 func (d *Document) TableName() string {
 	return "document"
 }

--- a/serve-api/entity/order.go
+++ b/serve-api/entity/order.go
@@ -12,7 +12,7 @@ const (
 	OrderTypeBOTH string = "BOTH"
 )
 
-// Client, Deputies, Documents need including
+// Order defines the information a order holds
 type Order struct {
 	gorm.Model
 	ID                      int `gorm:"not null;type:bigint;autoIncrement"`
@@ -34,6 +34,7 @@ type Order struct {
 	ApiResponse   string
 }
 
+// CreateOrder will create a order in the database with the passed in values
 func CreateOrder(
 	db *gorm.DB,
 	subType string,
@@ -63,14 +64,17 @@ func CreateOrder(
 	})
 }
 
+// SelectOrderByID will select a order by their ID
 func (o *Order) SelectOrderByID(db *gorm.DB, id int) *gorm.DB {
 	return db.First(o, id)
 }
 
+// GetType will return the order type
 func (o *Order) GetType() string {
 	return o.Type
 }
 
+// TableName refers to the table name used in the database
 func (o *Order) TableName() string {
 	return "dc_order"
 }

--- a/serve-api/entity/user.go
+++ b/serve-api/entity/user.go
@@ -7,6 +7,7 @@ import (
 	"gorm.io/gorm"
 )
 
+// User defines the information a user holds
 type User struct {
 	gorm.Model
 	ID                       uint32 `gorm:"not null;type:bigint;autoIncrement"`
@@ -21,14 +22,17 @@ type User struct {
 	PhoneNumber              string         `gorm:"size:20;"`
 }
 
+// CreateUser will create a user in the database with the passed in values
 func CreateUser(db *gorm.DB, email string, password string, roles []string, firstName string, lastName string, phoneNumber string) {
 	db.Create(&User{Email: email, Password: password, Roles: roles})
 }
 
+// SelectUserByID will select a user by their ID
 func (u *User) SelectUserByID(db *gorm.DB, id int) *gorm.DB {
 	return db.First(u, id)
 }
 
+// TableName refers to the table name used in the database
 func (u *User) TableName() string {
 	return "dc_user"
 }

--- a/serve-api/internal/cache/cache.go
+++ b/serve-api/internal/cache/cache.go
@@ -8,6 +8,8 @@ import (
 	"github.com/ministryofjustice/serve-opg/serve-api/internal/session"
 )
 
+// SecretCache stores the environment we are on
+// and a cache client for AWS Secrets Manager secrets
 type SecretsCache struct {
 	env   string
 	cache AwsSecretsCache
@@ -24,12 +26,16 @@ func applyAwsConfig(c *secretcache.Cache) {
 	c.Client = secretsmanager.New(sess.AWSSession)
 }
 
+// New constructs a new SecretsCache with the environment we are on
+// and a cache client for AWS Secrets Manager secrets
 func New() *SecretsCache {
 	env := os.Getenv("ENVIRONMENT")
 	cache, _ := secretcache.New(applyAwsConfig)
 	return &SecretsCache{env, cache}
 }
 
+// GetSecretString gets the secret string value from the cache for given secret id and a default version stage.
+// Returns the secret string and an error if operation failed.
 func (c *SecretsCache) GetSecretString(key string) (string, error) {
 	return c.cache.GetSecretString(c.env + "/" + key)
 }

--- a/serve-api/internal/db/db.go
+++ b/serve-api/internal/db/db.go
@@ -10,6 +10,8 @@ import (
 	"gorm.io/gorm"
 )
 
+// Connect will create a connection to the database
+// and return the gorm.DB connection
 func Connect() *gorm.DB {
 	db_host := os.Getenv("POSTGRES_HOST")
 	db_user := os.Getenv("POSTGRES_USER")
@@ -26,6 +28,7 @@ func Connect() *gorm.DB {
 	return db
 }
 
+// Migrate will create the tables in the database
 func Migrate(db *gorm.DB, entity entity.Entity) {
 	db.AutoMigrate(&entity)
 }

--- a/serve-api/internal/session/session.go
+++ b/serve-api/internal/session/session.go
@@ -8,10 +8,13 @@ import (
 	"github.com/aws/aws-sdk-go/aws/session"
 )
 
+// Session is a wrapper around the aws session
 type Session struct {
 	AWSSession *session.Session
 }
 
+// NewSession will create a new AWS session with our environments
+// AWS region and credentials
 func NewSession() (*Session, error) {
 	region := os.Getenv("AWS_REGION")
 


### PR DESCRIPTION
All exported functions/structs in Go should be commented with what they are trying to achieve. This allows the use of the `go doc` comment which will extract all exported functions into a documentation type web page with the comments explaining what each one is doing 