### PR TITLE
added: the call to the cancel() function returned from WithTimeout()

### DIFF
--- a/serve-api/main.go
+++ b/serve-api/main.go
@@ -6,6 +6,7 @@ import (
 	"net/http"
 	"os"
 	"os/signal"
+	"syscall"
 	"time"
 
 	"github.com/gorilla/mux"
@@ -46,11 +47,15 @@ func main() {
 		l.Println("Up and running!")
 	}()
 
-	//catching signal to gracefully shutdown
-	c := make(chan os.Signal)
-	signal.Notify(c, os.Interrupt, os.Kill)
+	// catching signal to gracefully shutdown
+	c := make(chan os.Signal, 1)
+	signal.Notify(c, os.Interrupt, syscall.SIGTERM)
 	sig := <-c
 	l.Println("Recieve terminate, gracefully shutting down", sig)
-	tc, _ := context.WithTimeout(context.Background(), 30*time.Second)
+
+	// shutting down the server
+	tc, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+
 	s.Shutdown(tc)
 }


### PR DESCRIPTION
Failing to cancel the context that WithTimeout() returns means the
goroutine created will be retained in memory indefinitley which causes
memory leaks

More learnings here: https://go.dev/src/context/context.go?s=9162:9288

>// The WithCancel, WithDeadline, and WithTimeout functions take a
// Context (the parent) and return a derived Context (the child) and a
// CancelFunc. Calling the CancelFunc cancels the child and its
// children, removes the parent's reference to the child, and stops
// any associated timers. Failing to call the CancelFunc leaks the
// child and its children until the parent is canceled or the timer
// fires. The go vet tool checks that CancelFuncs are used on all
// control-flow paths.