### PR TITLE
SER-176 - unset aws creds before allowing CI ingress

### DIFF
--- a/.github/workflows/behat.yml
+++ b/.github/workflows/behat.yml
@@ -76,13 +76,15 @@ jobs:
           echo "::add-mask::$BEHAT_PASSWORD"
           echo BEHAT_PASSWORD=$BEHAT_PASSWORD >> $GITHUB_ENV
     
-      - name: Unset AWS Credentials
-        run: |
-          echo "AWS_ACCESS_KEY_ID=" >> $GITHUB_ENV
-          echo "AWS_SECRET_ACCESS_KEY=" >> $GITHUB_ENV
-          echo "AWS_SESSION_TOKEN=" >> $GITHUB_ENV
-          echo "AWS_DEFAULT_REGION=" >> $GITHUB_ENV
-          echo "AWS_REGION=" >> $GITHUB_ENV
+      - name: Configure AWS Credentials
+        uses: aws-actions/configure-aws-credentials@v1
+        with:
+          aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
+          aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+          aws-region: eu-west-1
+          role-to-assume: arn:aws:iam::311462405659:role/serve-opg-ci
+          role-duration-seconds: 3600
+          role-session-name: ActionsIngress
 
       - name: Allow CI ingress
         run: |

--- a/.github/workflows/behat.yml
+++ b/.github/workflows/behat.yml
@@ -58,7 +58,7 @@ jobs:
         with:
           name: cluster_config
 
-      - name: Configure AWS Credentials
+      - name: Configure AWS Credentials for Behat Password
         uses: aws-actions/configure-aws-credentials@v1
         with:
           aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
@@ -66,7 +66,7 @@ jobs:
           aws-region: eu-west-1
           role-to-assume: arn:aws:iam::705467933182:role/serve-opg-ci
           role-duration-seconds: 3600
-          role-session-name: GitHubActions
+          role-session-name: BehatPasswordActions
       
       - name: Get Behat password
         run: |
@@ -76,6 +76,14 @@ jobs:
           echo "::add-mask::$BEHAT_PASSWORD"
           echo BEHAT_PASSWORD=$BEHAT_PASSWORD >> $GITHUB_ENV
     
+      - name: Unset AWS Credentials
+        run: |
+          echo "AWS_ACCESS_KEY_ID=" >> $GITHUB_ENV
+          echo "AWS_SECRET_ACCESS_KEY=" >> $GITHUB_ENV
+          echo "AWS_SESSION_TOKEN=" >> $GITHUB_ENV
+          echo "AWS_DEFAULT_REGION=" >> $GITHUB_ENV
+          echo "AWS_REGION=" >> $GITHUB_ENV
+
       - name: Allow CI ingress
         run: |
           echo $TF_WORKSPACE

--- a/.github/workflows/behat.yml
+++ b/.github/workflows/behat.yml
@@ -75,18 +75,19 @@ jobs:
           --region eu-west-1 | jq -r '.SecretString' 2>/dev/null)
           echo "::add-mask::$BEHAT_PASSWORD"
           echo BEHAT_PASSWORD=$BEHAT_PASSWORD >> $GITHUB_ENV
-    
-      - name: Configure AWS Credentials
-        uses: aws-actions/configure-aws-credentials@v1
-        with:
-          aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
-          aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
-          aws-region: eu-west-1
-          role-to-assume: arn:aws:iam::311462405659:role/serve-opg-ci
-          role-duration-seconds: 3600
-          role-session-name: ActionsIngress
+
+      - name: Unset AWS Credentials
+        run: |
+          echo "AWS_ACCESS_KEY_ID=" >> $GITHUB_ENV
+          echo "AWS_SECRET_ACCESS_KEY=" >> $GITHUB_ENV
+          echo "AWS_SESSION_TOKEN=" >> $GITHUB_ENV
+          echo "AWS_DEFAULT_REGION=" >> $GITHUB_ENV
+          echo "AWS_REGION=" >> $GITHUB_ENV
 
       - name: Allow CI ingress
+        env:
+          AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
+          AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
         run: |
           echo $TF_WORKSPACE
           python scripts/ci_ingress.py cluster_config.json --add
@@ -107,6 +108,9 @@ jobs:
           path: /tmp/behat
 
       - name: Remove CI ingress
+        env:
+          AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
+          AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
         run: |
           echo $TF_WORKSPACE
           python scripts/ci_ingress.py cluster_config.json


### PR DESCRIPTION
Unset aws config made by configure-aws-credentials before CI ingress runs, to allow proper roles to be assumed

Intent is to refactor this once the path to live is unblocked