### PR TITLE
DDPB-4472 fix auth to sirius

### DIFF
--- a/serve-web/api.public.v1.yaml
+++ b/serve-web/api.public.v1.yaml
@@ -21,7 +21,7 @@ paths:
               schema:
                 type: string
           description: CSRF token that is required for subsequent requests to Sirius
-  /auth/login:
+  /old-login:
     post:
       description: >
         **NOTE** this endpoint is not guaranteed in the upstream contract, but

--- a/serve-web/src/Service/SiriusService.php
+++ b/serve-web/src/Service/SiriusService.php
@@ -187,7 +187,7 @@ class SiriusService
             ', with params => ' . json_encode($params));
 
         return $this->httpClient->post(
-            'auth/login',
+            'old-login',
             $params
         );
     }

--- a/serve-web/tests/Service/SiriusServiceTest.php
+++ b/serve-web/tests/Service/SiriusServiceTest.php
@@ -25,7 +25,7 @@ use Prophecy\PhpUnit\ProphecyTrait;
 class SiriusServiceTest extends MockeryTestCase
 {
     use ProphecyTrait;
-    
+
     /**
      * @var SiriusService
      */
@@ -139,7 +139,7 @@ class SiriusServiceTest extends MockeryTestCase
             'documents' => $expectedDocuments,
         ];
 
-        $this->mockHttpClient->post('auth/login', Argument::any())->shouldBeCalled()->willReturn(
+        $this->mockHttpClient->post('old-login', Argument::any())->shouldBeCalled()->willReturn(
             new Response(200, ['X-XSRF-TOKEN' => 'pKxFAyMS+YXhuDuXB7TlhA=='])
         );
 


### PR DESCRIPTION
## Description

Due to a change to sirius frontend login, the auth/login endpoint no longer logs us in to sirius. As such we need to change it to the old-login endpoint instead.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Issues Resolved

DDPB-4472
## Merge check List

- [ ] New functionality includes testing
- [ ] New functionality has been documented in the README if applicable
- [ ] Approved by PMs
