### PR TITLE
Send OPG-Bypass-Membrane header with Sirius Auth

### DIFF
--- a/serve-web/src/Service/SiriusService.php
+++ b/serve-web/src/Service/SiriusService.php
@@ -235,7 +235,10 @@ class SiriusService
             [
                 'json' => $payload,
                 'cookies' => $this->cookieJar,
-                'headers' => ['X-XSRF-TOKEN' => $csrfToken]
+                'headers' => [
+                    'X-XSRF-TOKEN' => $csrfToken,
+                    'OPG-Bypass-Membrane' => '1',
+                ],
             ]
         );
     }

--- a/serve-web/tests/Service/SiriusServiceTest.php
+++ b/serve-web/tests/Service/SiriusServiceTest.php
@@ -147,7 +147,8 @@ class SiriusServiceTest extends MockeryTestCase
             'json' => $expectedPayload,
             'cookies' => new CookieJar(),
             'headers' => [
-                'X-XSRF-TOKEN' => 'pKxFAyMS+YXhuDuXB7TlhA=='
+                'X-XSRF-TOKEN' => 'pKxFAyMS+YXhuDuXB7TlhA==',
+                'OPG-Bypass-Membrane' => '1',
             ]
         ];
 


### PR DESCRIPTION
## Description

When authenticating against Sirius, use the `OPG-Bypass-Membrane` to avoid checking every request against Membrane.

This enables us to use non-Membrane authentication, such as via SSM.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Issues Resolved

[VEGA-1440](https://opgtransform.atlassian.net/browse/VEGA-1440)

## Merge check List

- [x] New functionality includes testing
- [x] New functionality has been documented in the README if applicable
  - N/A
- [ ] Approved by PMs
