### PR TITLE
SER-204 - Upgrade to latest version of aws notify slack #patch

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -54,6 +54,8 @@ jobs:
         continue-on-error: true
 
       - name: Terraform Init
+        env:
+          TF_WORKSPACE: ${{ inputs.workspace_name }}
         run: |
           terraform init -input=false
         working-directory: ./terraform

--- a/terraform/.terraform.lock.hcl
+++ b/terraform/.terraform.lock.hcl
@@ -43,6 +43,26 @@ provider "registry.terraform.io/hashicorp/aws" {
   ]
 }
 
+provider "registry.terraform.io/hashicorp/external" {
+  version     = "2.2.3"
+  constraints = ">= 1.0.0"
+  hashes = [
+    "h1:D2RKjqoU26isFINpmeKG9NS0LvkPmrQkNXeYO2TdgyA=",
+    "zh:184ecd339d764de845db0e5b8a9c87893dcd0c9d822167f73658f89d80ec31c9",
+    "zh:2661eaca31d17d6bbb18a8f673bbfe3fe1b9b7326e60d0ceb302017003274e3c",
+    "zh:2c0a180f6d1fc2ba6e03f7dfc5f73b617e45408681f75bca75aa82f3796df0e4",
+    "zh:4b92ae44c6baef4c4952c47be00541055cb5280dd3bc8031dba5a1b2ee982387",
+    "zh:5641694d5daf3893d7ea90be03b6fa575211a08814ffe70998d5adb8b59cdc0a",
+    "zh:5bd55a2be8a1c20d732ac9c604b839e1cadc8c49006315dffa4d709b6874df32",
+    "zh:6e0ef5d11e1597202424b7d69b9da7b881494c9b13a3d4026fc47012dc651c79",
+    "zh:78d5eefdd9e494defcb3c68d282b8f96630502cac21d1ea161f53cfe9bb483b3",
+    "zh:9e19f89fa25004d3b926a8d15ea630b4bde62f1fa4ed5e11a3d27aabddb77353",
+    "zh:b763efdd69fd097616b4a4c89cf333b4cee9699ac6432d73d2756f8335d1213f",
+    "zh:e3b561efdee510b2b445f76a52a902c52bee8e13095e7f4bed7c80f10f8d294a",
+    "zh:fe660bb8781ee043a093b9a20e53069974475dcaa5791a1f45fd03c61a26478a",
+  ]
+}
+
 provider "registry.terraform.io/hashicorp/local" {
   version = "2.3.0"
   hashes = [

--- a/terraform/notifications.tf
+++ b/terraform/notifications.tf
@@ -12,7 +12,7 @@ resource "aws_sns_topic" "alert_us_east" {
 }
 
 module "notify_slack" {
-  source = "github.com/terraform-aws-modules/terraform-aws-notify-slack.git?ref=v2.4.0"
+  source = "github.com/terraform-aws-modules/terraform-aws-notify-slack.git?ref=v5.6.0"
 
   sns_topic_name   = aws_sns_topic.alert.name
   create_sns_topic = false
@@ -30,7 +30,7 @@ module "notify_slack" {
 }
 
 module "notify_slack_us-east-1" {
-  source = "github.com/terraform-aws-modules/terraform-aws-notify-slack.git?ref=v2.4.0"
+  source = "github.com/terraform-aws-modules/terraform-aws-notify-slack.git?ref=v5.6.0"
 
   providers = {
     aws = aws.us-east-1


### PR DESCRIPTION
## Description
Upgrade to latest version of aws notify slack as the old version is using deprecated AWS Terraform resources

Setting TF_WORKSPACE for the init step is necessary to upgrade a v0.12 instance to v0.13 which the latest version of aws-notify-slack uses

SER-204