### PR TITLE
Add a prefix for us east iam role #patch

### DIFF
--- a/terraform/notifications.tf
+++ b/terraform/notifications.tf
@@ -42,6 +42,8 @@ module "notify_slack_us-east-1" {
 
   lambda_function_name = "notify-slack"
 
+  iam_role_name_prefix = "us-east-1"
+
   cloudwatch_log_group_retention_in_days = 14
 
   slack_webhook_url = data.aws_secretsmanager_secret_version.slack_url.secret_string


### PR DESCRIPTION
## Description

The upgrade of aws-notify-slack is trying to create two IAM roles with the same name.. added a prefix to the us-east-1 role to fix this