### PR TITLE
Exclude dependabot PRs from trying to push containers

### DIFF
--- a/.github/workflows/containers.yml
+++ b/.github/workflows/containers.yml
@@ -12,6 +12,7 @@ defaults:
 
 jobs:
   build_and_push_containers:
+    if: ${{ github.actor != 'dependabot[bot]' }}
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3


### PR DESCRIPTION
## Description

Fixes builds to avoid dependabot builds failing due to not having creds to push to ECR.