### PR TITLE
DDPB-4845 switch db to serverless v2

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -28,6 +28,8 @@ localstack-data
 /features/screenshots/*
 /tests/artifacts/behat/*
 /tests/artifacts/phpunit/*
+/terraform/cluster_config.json
+/terraform/builds/*
 
 /s3/
 /web/

--- a/terraform/.terraform.lock.hcl
+++ b/terraform/.terraform.lock.hcl
@@ -2,25 +2,26 @@
 # Manual edits may be lost in future updates.
 
 provider "registry.terraform.io/hashicorp/aws" {
-  version     = "5.10.0"
+  version     = "5.23.1"
   constraints = ">= 4.8.0, >= 4.9.0, >= 4.56.0"
   hashes = [
-    "h1:g0NYapqztQLdHycec4tlBGNQJTUXUY0Xy5/XUgjAD7U=",
-    "zh:24f8b40ba25521ec809906623ce1387542f3da848952167bc960663583a7b2c7",
-    "zh:3c12afbda4e8ed44ab8315d16bbba4329ef3f18ffe3c0d5ea456dd05472fa610",
-    "zh:4da2de97535c7fb51ede8ef9b6bd45c790005aec36daac4317a6175d2ff632fd",
-    "zh:5631fd3c02c5abe5e51a73bd77ddeaaf97b2d508845ea03bc1e5955b52d94706",
-    "zh:5bdef27b4e5b2dcd0661125fcc1e70826d545903b1e19bb8d28d2a0c812468d5",
-    "zh:7b7f6b3e00ad4b7bfaa9872388f7b8014d8c9a1fe5c3f9f57865535865727633",
-    "zh:935f7a599a3f55f69052b096491262d59787625ce5d52f729080328e5088e823",
+    "h1:keD9rGwuFbn70D1npMx486xFsSP/TtyNa6E0AgVJY1U=",
+    "h1:s23thJVPJHUdS7ESZHoeMkxNcTeaqWvg2usv8ylFVL4=",
+    "zh:024a188ad3c979a9ec0d7d898aaa90a3867a8839edc8d3543ea6155e6e010064",
+    "zh:05b73a04c58534a7527718ef55040577d5c573ea704e16a813e7d1b18a7f4c26",
+    "zh:13932cdee2fa90f40ebaa783f033752864eb6899129e055511359f8d1ada3710",
+    "zh:3500f5febc7878b4426ef89a16c0096eefd4dd0c5b0d9ba00f9ed54387df5d09",
+    "zh:394a48dea7dfb0ae40e506ccdeb5387829dbb8ab00fb64f41c347a1de092aa00",
+    "zh:51a57f258b3bce2c167b39b6ecf486f72f523da05d4c92adc6b697abe1c5ff1f",
+    "zh:7290488a96d8d10119b431eb08a37407c0812283042a21b69bcc2454eabc08ad",
+    "zh:7545389dbbba624c0ffa72fa376b359b27f484aba02139d37ee5323b589e0939",
+    "zh:92266ac6070809e0c874511ae93097c8b1eddce4c0213e487c5439e89b6ad64d",
     "zh:9b12af85486a96aedd8d7984b0ff811a4b42e3d88dad1a3fb4c0b580d04fa425",
-    "zh:a451a24f6675f8ad643a9b218cdb54c2af75a53d6a712daff46f64b81ec61032",
-    "zh:a5bcf820baefdc9f455222878f276a7f406a1092ac7b4c0cdbd6e588bff84847",
-    "zh:c9ab7b838a75bbcacc298658c1a04d1f0ee5935a928d821afcbe08c98cca7c5f",
-    "zh:d83855b6d66aaa03b1e66e03b7d0a4d1c9f992fce06f00011edde2a6ad6d91d6",
-    "zh:f1793e9a1e3ced98ca301ef1a294f46c06f77f6eb10f4d67ffef87ea60835421",
-    "zh:f366c99ddb16d75e07a687a60c015e8e2e0cdb593dea902385629571bd604859",
-    "zh:fb3ec60ea72144f480f495634c6d3e7a7638d7061a77c228a30768c1ae0b91f6",
+    "zh:9c3841bd650d6ba471c7159bcdfa35200e5e49c2ea11032c481a33cf7875879d",
+    "zh:bd103c46a16e7f9357e08d6427c316ccc56d203452130eed8e36ede3afa3322c",
+    "zh:cab0a16e320c6ca285a3a51f40c8f46dbaa0712856594819b415b4d8b3e63910",
+    "zh:e8adedcda4d6ff47dcae9c9bb884da26ca448fb6f7436be95ad6a341e4d8094a",
+    "zh:fc23701a3723f50878f440dcdf8768ea96d60a0d7c351aa6dfb912ad832c8384",
   ]
 }
 
@@ -29,6 +30,8 @@ provider "registry.terraform.io/hashicorp/external" {
   constraints = ">= 1.0.0"
   hashes = [
     "h1:9rJggijNdRdFk//ViQPGZdK0xu9XU/9qBDijNsZJMg0=",
+    "h1:bROCw6g5D/3fFnWeJ01L4IrdnJl1ILU8DGDgXCtYzaY=",
+    "h1:gznGscVJ0USxy4CdihpjRKPsKvyGr/zqPvBoFLJTQDc=",
     "zh:001e2886dc81fc98cf17cf34c0d53cb2dae1e869464792576e11b0f34ee92f54",
     "zh:2eeac58dd75b1abdf91945ac4284c9ccb2bfb17fa9bdb5f5d408148ff553b3ee",
     "zh:2fc39079ba61411a737df2908942e6970cb67ed2f4fb19090cd44ce2082903dd",
@@ -49,6 +52,8 @@ provider "registry.terraform.io/hashicorp/local" {
   constraints = ">= 1.0.0"
   hashes = [
     "h1:Bs7LAkV/iQTLv72j+cTMrvx2U3KyXrcVHaGbdns1NcE=",
+    "h1:R97FTYETo88sT2VHfMgkPU3lzCsZLunPftjSI5vfKe8=",
+    "h1:ZUEYUmm2t4vxwzxy1BvN1wL6SDWrDxfH7pxtzX8c6d0=",
     "zh:53604cd29cb92538668fe09565c739358dc53ca56f9f11312b9d7de81e48fab9",
     "zh:66a46e9c508716a1c98efbf793092f03d50049fa4a83cd6b2251e9a06aca2acf",
     "zh:70a6f6a852dd83768d0778ce9817d81d4b3f073fab8fa570bff92dcb0824f732",
@@ -65,9 +70,12 @@ provider "registry.terraform.io/hashicorp/local" {
 }
 
 provider "registry.terraform.io/hashicorp/null" {
-  version = "3.2.1"
+  version     = "3.2.1"
+  constraints = ">= 2.0.0"
   hashes = [
+    "h1:FbGfc+muBsC17Ohy5g806iuI1hQc4SIexpYCrQHQd8w=",
     "h1:tSj1mL6OQ8ILGqR2mDu7OYYYWf+hoir0pf9KAQ8IzO8=",
+    "h1:ydA0/SNRVB1o95btfshvYsmxA+jZFRZcvKzZSB+4S1M=",
     "zh:58ed64389620cc7b82f01332e27723856422820cfd302e304b5f6c3436fb9840",
     "zh:62a5cc82c3b2ddef7ef3a6f2fedb7b9b3deff4ab7b414938b08e51d6e8be87cb",
     "zh:63cff4de03af983175a7e37e52d4bd89d990be256b16b5c7f919aff5ad485aa5",

--- a/terraform/rds.tf
+++ b/terraform/rds.tf
@@ -39,6 +39,124 @@ resource "aws_rds_cluster_instance" "cluster_instances" {
   }
 }
 
+locals {
+  availability_zones        = ["eu-west-1a", "eu-west-1b", "eu-west-1c"]
+  serverless_engine_version = "13.12"
+}
+
+# See the following link for further information
+# https://docs.aws.amazon.com/kms/latest/developerguide/key-policies.html
+data "aws_iam_policy_document" "cloudwatch_kms" {
+  statement {
+    sid       = "Enable Root account permissions on Key"
+    effect    = "Allow"
+    actions   = ["kms:*"]
+    resources = ["*"]
+
+    principals {
+      type = "AWS"
+      identifiers = [
+        "arn:aws:iam::${data.aws_caller_identity.current.account_id}:root",
+      ]
+    }
+  }
+
+  statement {
+    sid       = "Allow Key to be used for Encryption"
+    effect    = "Allow"
+    resources = ["*"]
+    actions = [
+      "kms:Encrypt",
+      "kms:Decrypt",
+      "kms:ReEncrypt*",
+      "kms:GenerateDataKey*",
+      "kms:DescribeKey",
+    ]
+
+    principals {
+      type = "Service"
+      identifiers = [
+        "logs.${data.aws_region.current.name}.amazonaws.com",
+        "events.amazonaws.com"
+      ]
+    }
+  }
+}
+
+resource "aws_kms_key" "cloudwatch_logs" {
+  description             = "Serve cloudwatch logs for ${terraform.workspace}"
+  deletion_window_in_days = 10
+  enable_key_rotation     = true
+  policy                  = data.aws_iam_policy_document.cloudwatch_kms.json
+}
+
+resource "aws_cloudwatch_log_group" "api_cluster" {
+  name              = "/aws/rds/cluster/serve-opg-${terraform.workspace}/postgresql"
+  kms_key_id        = aws_kms_key.cloudwatch_logs.arn
+  retention_in_days = 180
+  tags              = local.default_tags
+}
+
+data "aws_kms_key" "rds" {
+  key_id = "alias/aws/rds"
+}
+
+resource "aws_rds_cluster" "cluster_serverless" {
+  cluster_identifier                  = "serve-opg-${terraform.workspace}-cluster"
+  apply_immediately                   = local.rds_deletion_protection ? false : true
+  availability_zones                  = local.availability_zones
+  backup_retention_period             = 14
+  copy_tags_to_snapshot               = true
+  database_name                       = "serve_opg"
+  db_subnet_group_name                = aws_db_subnet_group.database.name
+  deletion_protection                 = local.rds_deletion_protection ? true : false
+  engine                              = "aurora-postgresql"
+  engine_version                      = local.serverless_engine_version
+  engine_mode                         = "provisioned"
+  final_snapshot_identifier           = "serve-opg-${terraform.workspace}-final-snapshot"
+  kms_key_id                          = data.aws_kms_key.rds.arn
+  master_username                     = "serveopgadmin"
+  master_password                     = data.aws_secretsmanager_secret_version.database_password.secret_string
+  preferred_backup_window             = "05:15-05:45"
+  preferred_maintenance_window        = "mon:05:50-mon:06:20"
+  storage_encrypted                   = true
+  skip_final_snapshot                 = local.rds_deletion_protection ? false : true
+  vpc_security_group_ids              = [aws_security_group.database.id]
+  tags                                = local.default_tags
+  iam_database_authentication_enabled = false
+
+  serverlessv2_scaling_configuration {
+    min_capacity = 0.5
+    max_capacity = 16
+  }
+  depends_on = [aws_cloudwatch_log_group.api_cluster]
+}
+
+resource "aws_rds_cluster_instance" "serverless_instances" {
+  count                           = 2
+  cluster_identifier              = aws_rds_cluster.cluster_serverless.cluster_identifier
+  apply_immediately               = local.rds_deletion_protection ? false : true
+  auto_minor_version_upgrade      = false
+  db_subnet_group_name            = aws_db_subnet_group.database.name
+  depends_on                      = [aws_rds_cluster.cluster_serverless]
+  engine                          = aws_rds_cluster.cluster_serverless.engine
+  engine_version                  = aws_rds_cluster.cluster_serverless.engine_version
+  identifier                      = "serve-opg-${terraform.workspace}-${count.index}"
+  instance_class                  = "db.serverless"
+  monitoring_interval             = 30
+  monitoring_role_arn             = "arn:aws:iam::${var.accounts[terraform.workspace]}:role/rds-enhanced-monitoring"
+  performance_insights_enabled    = true
+  performance_insights_kms_key_id = data.aws_kms_key.rds.arn
+  publicly_accessible             = false
+  tags                            = local.default_tags
+
+  timeouts {
+    create = "180m"
+    update = "90m"
+    delete = "90m"
+  }
+}
+
 resource "aws_iam_role" "enhanced_monitoring" {
   name               = "rds-enhanced-monitoring"
   assume_role_policy = data.aws_iam_policy_document.enhanced_monitoring.json

--- a/terraform/task_definition.tf
+++ b/terraform/task_definition.tf
@@ -289,19 +289,19 @@ EOF
   	},
     {
       "name": "DC_DB_HOST",
-      "value": "${aws_rds_cluster.serve_opg.endpoint}"
+      "value": "${aws_rds_cluster.cluster_serverless.endpoint}"
     },
     {
       "name": "DC_DB_PORT",
-      "value": "${aws_rds_cluster.serve_opg.port}"
+      "value": "${aws_rds_cluster.cluster_serverless.port}"
     },
     {
       "name": "DC_DB_NAME",
-      "value": "${aws_rds_cluster.serve_opg.database_name}"
+      "value": "${aws_rds_cluster.cluster_serverless.database_name}"
     },
     {
       "name": "DC_DB_USER",
-      "value": "${aws_rds_cluster.serve_opg.master_username}"
+      "value": "${aws_rds_cluster.cluster_serverless.master_username}"
     },
     {
       "name": "TIMEOUT",
@@ -360,4 +360,3 @@ EOF
 EOF
 
 }
-


### PR DESCRIPTION
## Description

Move to serverless v2 without destroying current provisioned DB.

Next follow up ticket will destroy the current DB.

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Issues Resolved

DDPB-4845 

## Merge check List

- [ ] New functionality includes testing
- [ ] New functionality has been documented in the README if applicable
- [ ] Approved by PMs
