### PR TITLE
DDPB-4845b remove deletion protection from original DB

### DIFF
--- a/terraform/rds.tf
+++ b/terraform/rds.tf
@@ -3,7 +3,7 @@ resource "aws_rds_cluster" "serve_opg" {
   master_username              = "serveopgadmin"
   engine                       = "aurora-postgresql"
   engine_version               = local.postgres_engine_version
-  skip_final_snapshot          = local.rds_deletion_protection ? false : true
+  skip_final_snapshot          = true
   final_snapshot_identifier    = "serve-opg-${terraform.workspace}"
   database_name                = "serve_opg"
   db_subnet_group_name         = aws_db_subnet_group.database.name
@@ -12,7 +12,7 @@ resource "aws_rds_cluster" "serve_opg" {
   deletion_protection          = local.rds_deletion_protection
   tags                         = local.default_tags
   allow_major_version_upgrade  = true
-  apply_immediately            = local.rds_deletion_protection ? false : true
+  apply_immediately            = true
   preferred_backup_window      = "05:15-05:45"
   preferred_maintenance_window = "mon:05:50-mon:06:20"
 
@@ -211,4 +211,3 @@ resource "aws_security_group_rule" "database_tcp_out" {
   source_security_group_id = aws_security_group.ecs_service.id
   type                     = "egress"
 }
-


### PR DESCRIPTION
## Description

We don't need egress sg rule for RDS. Not sure why it's there. Removing the deletion protection to old DB in this PR so that we may delete the old DBs in next PR.

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Issues Resolved

DDPB-4845b 

## Merge check List

- [ ] New functionality includes testing
- [ ] New functionality has been documented in the README if applicable
- [ ] Approved by PMs
