### PR TITLE
SER-229 readd c9 to tfstate

### DIFF
--- a/terraform/account/cloud9.tf
+++ b/terraform/account/cloud9.tf
@@ -1,28 +1,28 @@
-#locals {
-#  cloud9_users_from_secret         = jsondecode(data.aws_secretsmanager_secret_version.cloud9_users.secret_string)["user_names"]
-#  cloud9_owner_from_secret         = jsondecode(data.aws_secretsmanager_secret_version.cloud9_users.secret_string)["owner"]
-#  cloud9_owner_session_from_secret = jsondecode(data.aws_secretsmanager_secret_version.cloud9_users.secret_string)["owner_session"]
-#  cloud9_users_for_each = {
-#    for user, user in local.cloud9_users_from_secret : user => user
-#  }
-#}
-#
-#resource "aws_cloud9_environment_ec2" "shared" {
-#  instance_type               = "t2.micro"
-#  name                        = "team-cloud9-env"
-#  automatic_stop_time_minutes = 20
-#  image_id                    = "amazonlinux-2-x86_64"
-#  description                 = "Shared Cloud9 instance to be used by all devs"
-#  subnet_id                   = aws_subnet.private[0].id
-#  connection_type             = "CONNECT_SSM"
-#  owner_arn                   = "arn:aws:iam::${local.account.account_id}:assumed-role/${nonsensitive(local.cloud9_owner_from_secret)}/${nonsensitive(local.cloud9_owner_session_from_secret)}"
-#  tags                        = local.default_tags
-#}
-#
-#resource "aws_cloud9_environment_membership" "shared" {
-#  for_each = nonsensitive(local.cloud9_users_for_each)
-#
-#  environment_id = aws_cloud9_environment_ec2.shared.id
-#  permissions    = "read-write"
-#  user_arn       = "arn:aws:iam::${local.account.account_id}:assumed-role/operator/${each.value}"
-#}
+locals {
+  cloud9_users_from_secret         = jsondecode(data.aws_secretsmanager_secret_version.cloud9_users.secret_string)["user_names"]
+  cloud9_owner_from_secret         = jsondecode(data.aws_secretsmanager_secret_version.cloud9_users.secret_string)["owner"]
+  cloud9_owner_session_from_secret = jsondecode(data.aws_secretsmanager_secret_version.cloud9_users.secret_string)["owner_session"]
+  cloud9_users_for_each = {
+    for user, user in local.cloud9_users_from_secret : user => user
+  }
+}
+
+resource "aws_cloud9_environment_ec2" "shared" {
+  instance_type               = "t2.micro"
+  name                        = "team-cloud9-env"
+  automatic_stop_time_minutes = 20
+  image_id                    = "amazonlinux-2-x86_64"
+  description                 = "Shared Cloud9 instance to be used by all devs"
+  subnet_id                   = aws_subnet.private[0].id
+  connection_type             = "CONNECT_SSM"
+  owner_arn                   = "arn:aws:iam::${local.account.account_id}:assumed-role/${nonsensitive(local.cloud9_owner_from_secret)}/${nonsensitive(local.cloud9_owner_session_from_secret)}"
+  tags                        = local.default_tags
+}
+
+resource "aws_cloud9_environment_membership" "shared" {
+  for_each = nonsensitive(local.cloud9_users_for_each)
+
+  environment_id = aws_cloud9_environment_ec2.shared.id
+  permissions    = "read-write"
+  user_arn       = "arn:aws:iam::${local.account.account_id}:assumed-role/operator/${each.value}"
+}

--- a/terraform/account/secrets.tf
+++ b/terraform/account/secrets.tf
@@ -26,6 +26,6 @@ resource "aws_secretsmanager_secret" "cloud9_users" {
   tags        = local.default_tags
 }
 
-#data "aws_secretsmanager_secret_version" "cloud9_users" {
-#  secret_id = aws_secretsmanager_secret.cloud9_users.id
-#}
+data "aws_secretsmanager_secret_version" "cloud9_users" {
+  secret_id = aws_secretsmanager_secret.cloud9_users.id
+}

--- a/terraform/environment/terraform.tfvars.json
+++ b/terraform/environment/terraform.tfvars.json
@@ -52,7 +52,7 @@
       "deletion_protection": "false",
       "postgres_version": "13.12",
       "rds_instance_count": 1,
-      "cloud9_env_id": "b80640a9517d4a108aa5950c1cdebc43"
+      "cloud9_env_id": "8aca4c4f8c7545ffa4e2a999ae17101a"
     }
   }
 }


### PR DESCRIPTION
## Description
We had to remove the c9 from tfstate as part of the move to environments. This PR in conjunction with some background tf state moves readds it back in.

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Issues Resolved

SER-229 [List any existing issues this PR resolves]

## Merge check List

- [ ] New functionality includes testing
- [ ] New functionality has been documented in the README if applicable
- [ ] Approved by PMs
