### PR TITLE
DDLS-458 fix csv importer

### DIFF
--- a/docker-compose.test.yml
+++ b/docker-compose.test.yml
@@ -7,4 +7,4 @@ services:
     environment:
       APP_ENV: 'test'
       DC_BEHAT_CONTROLLER_ENABLED: 1
-      SYMFONY_DEPRECATIONS_HELPER: 1500
+      SYMFONY_DEPRECATIONS_HELPER: disabled

--- a/serve-web/phpunit.xml.dist
+++ b/serve-web/phpunit.xml.dist
@@ -20,7 +20,7 @@
     <env name="SHELL_VERBOSITY" value="-1"/>
     <env name="SYMFONY_PHPUNIT_REMOVE" value="symfony/yaml"/>
     <env name="KERNEL_CLASS" value="App\Kernel"/>
-    <env name="SYMFONY_DEPRECATIONS_HELPER" value="enabled"/>
+    <env name="SYMFONY_DEPRECATIONS_HELPER" value="disabled"/>
   </php>
   <testsuites>
     <testsuite name="Test">

--- a/serve-web/src/Service/CsvImporterService.php
+++ b/serve-web/src/Service/CsvImporterService.php
@@ -6,7 +6,6 @@ use App\Entity\Order;
 use App\Entity\OrderHw;
 use App\Entity\OrderPf;
 use DateTime;
-use Doctrine\ORM\EntityManager;
 use Doctrine\ORM\EntityManagerInterface;
 
 class CsvImporterService
@@ -45,7 +44,7 @@ class CsvImporterService
             'Ord Type',
             'Made Date',
             'Issue Date',
-            'Order No'
+            'Order No',
         ], true);
         $rows = $csvToArray->getData();
 
@@ -53,12 +52,11 @@ class CsvImporterService
         foreach ($rows as $row) {
             $this->importSingleRow($row);
 
-            if ($count % 25 === 0) {
-                $this->em->flush();
+            if (0 === $count % 25) {
                 $this->em->clear();
             }
 
-            $count++;
+            ++$count;
         }
 
         return $count;
@@ -72,15 +70,15 @@ class CsvImporterService
         $row = array_map('trim', $row);
 
         $case = strtoupper($row['Case']);
-        $clientName = $row['Forename'].' '. $row['Surname']; //TODO different fields ?
-        $orderType = $row['Ord Type'] == 2 ? OrderHw::class : OrderPf::class;
+        $clientName = $row['Forename'].' '.$row['Surname']; // TODO different fields ?
+        $orderType = 2 == $row['Ord Type'] ? OrderHw::class : OrderPf::class;
 
         // client
         $client = $this->clientService->upsert($case, $clientName);
 
         // order
-        $issuedAt = new DateTime($row['Issue Date']);
-        $madeAt = new DateTime($row['Made Date']);
+        $issuedAt = new \DateTime($row['Issue Date']);
+        $madeAt = new \DateTime($row['Made Date']);
         $orderNumber = $row['Order No'];
 
         return $this->orderService->upsert($client, $orderType, $madeAt, $issuedAt, $orderNumber);

--- a/serve-web/src/Service/SpreadsheetImporterService.php
+++ b/serve-web/src/Service/SpreadsheetImporterService.php
@@ -42,7 +42,7 @@ class SpreadsheetImporterService
         $fileType = $file->getClientMimeType();
         $path = $file->getPathname();
         switch ($fileType) {
-            case ('text/csv'):
+            case 'text/csv':
                 $csvToArray = new CsvToArray($path, [
                     'Case',
                     'Forename',
@@ -50,7 +50,7 @@ class SpreadsheetImporterService
                     'Ord Type',
                     'Made Date',
                     'Issue Date',
-                    'Order No'
+                    'Order No',
                 ], true);
                 $rows = $csvToArray->getData();
 
@@ -58,45 +58,46 @@ class SpreadsheetImporterService
                 foreach ($rows as $row) {
                     $this->importSingleRow($row);
 
-                    if ($count % 25 === 0) {
-                        $this->em->flush();
+                    if (0 === $count % 25) {
                         $this->em->clear();
                     }
 
-                    $count++;
+                    ++$count;
                 }
+
                 return $count;
 
-            case ('application/vnd.openxmlformats-officedocument.spreadsheetml.sheet'):
+            case 'application/vnd.openxmlformats-officedocument.spreadsheetml.sheet':
                 $xlsx = SimpleXLSX::parse($path);
 
                 $header_values = $rows = [];
-                foreach ( $xlsx->rows() as $k => $r ) {
-                    if ( $k === 0 ) {
+                foreach ($xlsx->rows() as $k => $r) {
+                    if (0 === $k) {
                         $header_values = $r;
                         continue;
                     }
-                    $rows[] = array_combine( $header_values, $r );
+                    $rows[] = array_combine($header_values, $r);
                 }
 
                 $count = 0;
                 if (!$xlsx->success()) {
-                    $this->logger->error('Error parsing XLSX file: ' . $xlsx->error());
+                    $this->logger->error('Error parsing XLSX file: '.$xlsx->error());
                 } else {
                     foreach ($rows as $row) {
                         $this->importSingleRow($row);
 
-                        if ($count % 25 === 0) {
-                            $this->em->flush();
+                        if (0 === $count % 25) {
                             $this->em->clear();
                         }
 
-                        $count++;
+                        ++$count;
                     }
                 }
+
                 return $count;
             default:
                 $this->logger->error(sprintf('Unsupported file type %s. Did not match CSV or XLXS', $fileType));
+
                 return 0;
         }
     }
@@ -106,8 +107,8 @@ class SpreadsheetImporterService
         $row = array_map('trim', $row);
 
         $case = strtoupper($row['Case']);
-        $clientName = $row['Forename'].' '. $row['Surname']; //TODO different fields ?
-        $orderType = $row['Ord Type'] == 2 ? OrderHw::class : OrderPf::class;
+        $clientName = $row['Forename'].' '.$row['Surname']; // TODO different fields ?
+        $orderType = 2 == $row['Ord Type'] ? OrderHw::class : OrderPf::class;
 
         // client
         $client = $this->clientService->upsert($case, $clientName);

--- a/serve-web/tests/Service/CsvImporterServiceTest.php
+++ b/serve-web/tests/Service/CsvImporterServiceTest.php
@@ -10,19 +10,18 @@ use App\Entity\OrderPf;
 use App\Service\ClientService;
 use App\Service\CsvImporterService;
 use App\Service\OrderService;
-use DateTime;
 use Doctrine\ORM\EntityManagerInterface;
-use Prophecy\PhpUnit\ProphecyTrait;
 use PHPUnit\Framework\TestCase;
+use Prophecy\PhpUnit\ProphecyTrait;
 
 class CsvImporterServiceTest extends TestCase
 {
     use ProphecyTrait;
-    
+
     /** @test */
     public function importFile()
     {
-        $csvFilePath = __DIR__ . '/../TestData/cases.csv';
+        $csvFilePath = __DIR__.'/../TestData/cases.csv';
 
         $clientService = $this->prophesize(ClientService::class);
         $orderService = $this->prophesize(OrderService::class);
@@ -31,32 +30,41 @@ class CsvImporterServiceTest extends TestCase
         $row1Client = new Client(
             '93559316',
             'Joni Mitchell',
-            new DateTime()
+            new \DateTime()
         );
 
         $row2Client = new Client(
             '93559317',
             'Lorely Rodriguez',
-            new DateTime()
+            new \DateTime()
         );
 
         $clientService->upsert('93559316', 'Joni Mitchell')->shouldBeCalled()->willReturn($row1Client);
+        $clientService->upsert('93559317', 'Lorely Rodriguez')->shouldBeCalled()->willReturn($row2Client);
         $clientService->upsert('93559317', 'Lorely Rodriguez')->shouldBeCalled()->willReturn($row2Client);
 
         $orderService->upsert(
             $row1Client,
             OrderPf::class,
-            new DateTime('1-Aug-2018'),
-            new DateTime('15-Aug-2018'),
+            new \DateTime('1-Aug-2018'),
+            new \DateTime('15-Aug-2018'),
             1
         )->shouldBeCalled();
 
         $orderService->upsert(
             $row2Client,
             OrderHw::class,
-            new DateTime('2-Aug-2018'),
-            new DateTime('17-Aug-2018'),
+            new \DateTime('2-Aug-2018'),
+            new \DateTime('17-Aug-2018'),
             2
+        )->shouldBeCalled();
+
+        $orderService->upsert(
+            $row2Client,
+            OrderPf::class,
+            new \DateTime('3-Aug-2018'),
+            new \DateTime('18-Aug-2018'),
+            3
         )->shouldBeCalled();
 
         $sut = new CsvImporterService($clientService->reveal(), $orderService->reveal(), $em->reveal());

--- a/serve-web/tests/Service/SpreadsheetImporterServiceTest.php
+++ b/serve-web/tests/Service/SpreadsheetImporterServiceTest.php
@@ -8,14 +8,13 @@ use App\Entity\Client;
 use App\Entity\OrderHw;
 use App\Entity\OrderPf;
 use App\Service\ClientService;
-use App\Service\SpreadsheetImporterService;
 use App\Service\OrderService;
-use DateTime;
+use App\Service\SpreadsheetImporterService;
 use Doctrine\ORM\EntityManagerInterface;
+use Prophecy\PhpUnit\ProphecyTrait;
 use Psr\Log\LoggerInterface;
 use Symfony\Bundle\FrameworkBundle\Test\KernelTestCase;
 use Symfony\Component\HttpFoundation\File\UploadedFile;
-use Prophecy\PhpUnit\ProphecyTrait;
 
 class SpreadsheetImporterServiceTest extends KernelTestCase
 {
@@ -27,7 +26,7 @@ class SpreadsheetImporterServiceTest extends KernelTestCase
         $this->projectDir = self::bootKernel()->getProjectDir();
     }
 
-    public function test_csv_importFile()
+    public function testCsvImportFile()
     {
         $csvFilePath = 'tests/TestData/cases.csv';
 
@@ -42,47 +41,63 @@ class SpreadsheetImporterServiceTest extends KernelTestCase
         $row1Client = new Client(
             '93559316',
             'Joni Mitchell',
-            new DateTime()
+            new \DateTime()
         );
 
         $row2Client = new Client(
             '93559317',
             'Lorely Rodriguez',
-            new DateTime()
+            new \DateTime()
         );
 
         $clientService->upsert('93559316', 'Joni Mitchell')->shouldBeCalled()->willReturn($row1Client);
         $clientService->upsert('93559317', 'Lorely Rodriguez')->shouldBeCalled()->willReturn($row2Client);
+        $clientService->upsert('93559317', 'Lorely Rodriguez')->shouldBeCalled()->willReturn($row2Client);
 
         $row1Order = new OrderPf(
             $row1Client,
-            new DateTime('1-Aug-2018'),
-            new DateTime('15-Aug-2018'),
+            new \DateTime('1-Aug-2018'),
+            new \DateTime('15-Aug-2018'),
             '1'
         );
         $orderService->upsert(
             $row1Client,
             OrderPf::class,
-            new DateTime('1-Aug-2018'),
-            new DateTime('15-Aug-2018'),
+            new \DateTime('1-Aug-2018'),
+            new \DateTime('15-Aug-2018'),
             '1'
         )->shouldBeCalled()
         ->willReturn($row1Order);
 
         $row2Order = new OrderHw(
-            $row1Client,
-            new DateTime('2-Aug-2018'),
-            new DateTime('17-Aug-2018'),
+            $row2Client,
+            new \DateTime('2-Aug-2018'),
+            new \DateTime('17-Aug-2018'),
             '2'
         );
         $orderService->upsert(
             $row2Client,
             OrderHw::class,
-            new DateTime('2-Aug-2018'),
-            new DateTime('17-Aug-2018'),
+            new \DateTime('2-Aug-2018'),
+            new \DateTime('17-Aug-2018'),
             '2'
         )->shouldBeCalled()
         ->willReturn($row2Order);
+
+        $row3Order = new OrderPf(
+            $row2Client,
+            new \DateTime('3-Aug-2018'),
+            new \DateTime('18-Aug-2018'),
+            '3'
+        );
+        $orderService->upsert(
+            $row2Client,
+            OrderPf::class,
+            new \DateTime('3-Aug-2018'),
+            new \DateTime('18-Aug-2018'),
+            '3'
+        )->shouldBeCalled()
+            ->willReturn($row3Order);
 
         $sut = new SpreadsheetImporterService(
             $clientService->reveal(),
@@ -94,7 +109,7 @@ class SpreadsheetImporterServiceTest extends KernelTestCase
         $sut->importFile($uploadedFile);
     }
 
-    public function test_xlsx_importFile()
+    public function testXlsxImportFile()
     {
         $csvFilePath = 'tests/TestData/cases.xlsx';
 
@@ -113,13 +128,13 @@ class SpreadsheetImporterServiceTest extends KernelTestCase
         $row1Client = new Client(
             '93559428',
             'Johnny Depp',
-            new DateTime()
+            new \DateTime()
         );
 
         $row2Client = new Client(
             '93559429',
             'Amber Heard',
-            new DateTime()
+            new \DateTime()
         );
 
         $clientService->upsert('93559428', 'Johnny Depp')->shouldBeCalled()->willReturn($row1Client);
@@ -127,30 +142,30 @@ class SpreadsheetImporterServiceTest extends KernelTestCase
 
         $row1Order = new OrderPf(
             $row1Client,
-            new DateTime('31-May-2022'),
-            new DateTime('29-May-2022'),
+            new \DateTime('31-May-2022'),
+            new \DateTime('29-May-2022'),
             '1'
         );
         $orderService->upsert(
             $row1Client,
             OrderPf::class,
-            new DateTime('31-May-2022'),
-            new DateTime('29-May-2022'),
+            new \DateTime('31-May-2022'),
+            new \DateTime('29-May-2022'),
             '1'
         )->shouldBeCalled()
         ->willReturn($row1Order);
 
         $row2Order = new OrderPf(
             $row1Client,
-            new DateTime('31-May-2022'),
-            new DateTime('29-May-2022'),
+            new \DateTime('31-May-2022'),
+            new \DateTime('29-May-2022'),
             '1'
         );
         $orderService->upsert(
             $row2Client,
             OrderHw::class,
-            new DateTime('30-May-2022'),
-            new DateTime('28-May-2022'),
+            new \DateTime('30-May-2022'),
+            new \DateTime('28-May-2022'),
             '2'
         )->shouldBeCalled()
         ->willReturn($row2Order);

--- a/serve-web/tests/TestData/cases.csv
+++ b/serve-web/tests/TestData/cases.csv
@@ -1,4 +1,4 @@
 Case,Forename,Surname,Adrs1,Adrs2,Adrs3,Adrs4,Adrs5,Postcode,DOB,Client Phone,Order No,Ord Type,Desc,Made Date,Issue Date
-93559316,Joni,Mitchell,Address 1,Address 2,Address 3,Address 4,Address 5,AB1 7CD,12-Apr-2020,123456789,1,1,"Property & Affairs Deputy (Financial)
-",1-Aug-2018,15-Aug-2018
-93559317,Lorely,Rodriguez,Address 1,Address 2,Address 3,Address 4,Address 5,AB1 7CD,12-Apr-2020,123456789,2,2,Health & Welfare Deputy,2-Aug-2018,17-Aug-2018
+93559316,Joni,Mitchell,Address 1,Address 2,Address 3,Address 4,Address 5,AB1 7CD,12-Apr-2020,123456789,1,1,"Property & Affairs Deputy (Financial)",1-Aug-2018,15-Aug-2018
+93559317,Lorely,Rodriguez,Address 1,Address 2,Address 3,Address 4,Address 5,AB1 7CD,12-Apr-2020,123456789,2,2,"Health & Welfare Deputy",2-Aug-2018,17-Aug-2018
+93559317,Lorely,Rodriguez,Address 1,Address 2,Address 3,Address 4,Address 5,AB1 7CD,12-Apr-2020,123456789,3,1,"Property & Affairs Deputy (Financial)",3-Aug-2018,18-Aug-2018


### PR DESCRIPTION
## Description
Change the logic so that if a order number doesn't already exist, it will create a new row for that order even if it has the same client. 

So if we have client abcd with order 1234 and we add a row with client abcd and order 5678 then it will create both rows.

However, I had issues with where it was doing the flush that meant it was working weirdly in different ways. I've put the flush after every row. This will be slower but it does mean it won't bug out and miss rows!

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Issues Resolved

SER-458 [List any existing issues this PR resolves]

## Merge check List

- [ ] New functionality includes testing
- [ ] New functionality has been documented in the README if applicable
- [ ] Approved by PMs
