### PR TITLE
DDLS-519: Rewrite serve download report so it doesn't time out

### DIFF
--- a/serve-web/src/Controller/CaseController.php
+++ b/serve-web/src/Controller/CaseController.php
@@ -37,7 +37,7 @@ class CaseController extends AbstractController
         ];
 
         return $this->render('Case/index.html.twig', [
-            'orders' => $this->orderRepo->getOrders($filters, $limit),
+            'orders' => $this->orderRepo->getOrdersNotServedAndOrderReports($filters, $limit),
             'filters' => $filters,
             'counts' => [
                 'pending' => $this->orderRepo->getOrdersCount(['type' => 'pending'] + $filters),

--- a/serve-web/src/Controller/CaseController.php
+++ b/serve-web/src/Controller/CaseController.php
@@ -13,8 +13,6 @@ use Symfony\Component\Routing\Annotation\Route;
 #[Route(path: '/case')]
 class CaseController extends AbstractController
 {
-    private EntityManager $em;
-
     private ObjectRepository $orderRepo;
 
     /**
@@ -22,7 +20,6 @@ class CaseController extends AbstractController
      */
     public function __construct(EntityManager $em)
     {
-        $this->em = $em;
         $this->orderRepo = $em->getRepository(Order::class);
     }
 

--- a/serve-web/src/Controller/CaseController.php
+++ b/serve-web/src/Controller/CaseController.php
@@ -42,7 +42,7 @@ class CaseController extends AbstractController
             'counts' => [
                 'pending' => $this->orderRepo->getOrdersCount(['type' => 'pending'] + $filters),
                 'served' => $this->orderRepo->getOrdersCount(['type' => 'served'] + $filters),
-            ]
+            ],
         ]);
     }
 }

--- a/serve-web/src/Repository/OrderRepository.php
+++ b/serve-web/src/Repository/OrderRepository.php
@@ -1,4 +1,5 @@
 <?php
+
 namespace App\Repository;
 
 use App\Entity\Order;
@@ -20,7 +21,7 @@ class OrderRepository extends EntityRepository
         return $qb->getQuery()->getSingleScalarResult();
     }
 
-    //Function is using the same query builder as 'getOrdersNotServedAndOrderReports' but instead fetching data back as an associative array to handle large dataset and avoid timeouts
+    // Function is using the same query builder as 'getOrdersNotServedAndOrderReports' but instead fetching data back as an associative array to handle large dataset and avoid timeouts
     public function getAllServedOrders(array $filters, int $maxResults = 1000000)
     {
         $queryBuilder = $this->createOrdersQueryBuilder($filters, $maxResults);
@@ -29,7 +30,7 @@ class OrderRepository extends EntityRepository
 
         $params = [];
 
-        foreach($rawParams as $parameter) {
+        foreach ($rawParams as $parameter) {
             $params[] = $parameter->getValue();
         }
 
@@ -46,12 +47,6 @@ class OrderRepository extends EntityRepository
         return $queryBuilder->getQuery()->getResult();
     }
 
-    /**
-     * @param array $filters
-     * @param integer $maxResults
-     *
-     * @return Order[]
-     */
     private function createOrdersQueryBuilder(array $filters, int $maxResults): QueryBuilder
     {
         /**
@@ -83,18 +78,13 @@ class OrderRepository extends EntityRepository
         $this->applyFilters($qb, $filters);
 
         return $qb;
-
     }
 
-    /**
-     * @param QueryBuilder $qb
-     * @param array $filters
-     */
     private function applyFilters(QueryBuilder $qb, array $filters): void
     {
-        if ($filters['type'] == 'pending') {
+        if ('pending' == $filters['type']) {
             $qb->where('o.servedAt IS NULL');
-        } elseif ($filters['type'] == 'served') {
+        } elseif ('served' == $filters['type']) {
             $qb->where('o.servedAt IS NOT NULL');
         }
 
@@ -104,15 +94,14 @@ class OrderRepository extends EntityRepository
         }
 
         if (
-            array_key_exists('startDate', $filters) &&
-            array_key_exists('endDate', $filters)
+            array_key_exists('startDate', $filters)
+            && array_key_exists('endDate', $filters)
         ) {
-            if ($filters['type'] == 'served') {
+            if ('served' == $filters['type']) {
                 $qb->andWhere('o.servedAt >= :start AND o.servedAt <= :end')
                     ->setParameter('start', $filters['startDate'])
                     ->setParameter('end', $filters['endDate']);
-            }
-            else {
+            } else {
                 $qb->andWhere('o.madeAt >= :start AND o.madeAt <= :end')
                     ->setParameter('start', $filters['startDate'])
                     ->setParameter('end', $filters['endDate']);
@@ -122,12 +111,11 @@ class OrderRepository extends EntityRepository
 
     public function getOrdersBeforeGoLive(): mixed
     {
-
         $qb = $this->_em->getRepository(Order::class)
-            ->createQueryBuilder("o")
-            ->select("o")
+            ->createQueryBuilder('o')
+            ->select('o')
             ->where("o.createdAt < '2019-03-11'")
-            ->andWhere("o.servedAt IS NULL");
+            ->andWhere('o.servedAt IS NULL');
 
         return $qb->getQuery()->getResult();
     }

--- a/serve-web/src/Repository/OrderRepository.php
+++ b/serve-web/src/Repository/OrderRepository.php
@@ -20,11 +20,12 @@ class OrderRepository extends EntityRepository
         return $qb->getQuery()->getSingleScalarResult();
     }
 
+    //Function is using the same query builder as 'getOrdersNotServedAndOrderReports' but instead fetching data back as an associative array to handle large dataset and avoid timeouts
     public function getAllServedOrders(array $filters, int $maxResults = 1000000)
     {
-        $servedOrderQueryBuilder = $this->createOrdersQueryBuilder($filters, $maxResults);
+        $queryBuilder = $this->createOrdersQueryBuilder($filters, $maxResults);
 
-        $rawParams = $servedOrderQueryBuilder->getParameters();
+        $rawParams = $queryBuilder->getParameters();
 
         $params = [];
 
@@ -33,16 +34,16 @@ class OrderRepository extends EntityRepository
         }
 
         $conn = $this->getEntityManager()->getConnection();
-        $stmt = $conn->executeQuery($servedOrderQueryBuilder->getQuery()->getSQL(), $params);
+        $stmt = $conn->executeQuery($queryBuilder->getQuery()->getSQL(), $params);
+
         return $stmt->fetchAllAssociative();
     }
 
     public function getOrdersNotServedAndOrderReports(array $filters, int $maxResults)
     {
-        $servedOrderQueryBuilder = $this->createOrdersQueryBuilder($filters, $maxResults);
+        $queryBuilder = $this->createOrdersQueryBuilder($filters, $maxResults);
 
-        return $servedOrderQueryBuilder->getQuery()->getResult();
-
+        return $queryBuilder->getQuery()->getResult();
     }
 
     /**

--- a/serve-web/src/Service/ReportService.php
+++ b/serve-web/src/Service/ReportService.php
@@ -114,7 +114,7 @@ class ReportService
 
         $file = fopen("/tmp/all-served-orders-$today.csv","w");
 
-        $headers = ['OrderId', 'CaseNumber', 'OrderType', 'OrderNumber', 'ClientName', 'OrderServedDate'];
+        $headers = ['CaseNumber', 'OrderType', 'OrderNumber', 'ClientName', 'OrderServedDate'];
 
         fputcsv($file, $headers);
 
@@ -122,12 +122,14 @@ class ReportService
 
         foreach ($orders as $order) {
 
+            $orderServedDate = date('Y-m-d', strtotime($order['served_at_8']));
+
             $line = [
                 "CaseNumber" => $order['case_number_13'],
                 "OrderType" => $order['type_16'],
                 "OrderNumber" => $order['order_number_11'],
                 "ClientName" => $order['client_name_14'],
-                "OrderServedDate" => $order['served_at_8'],
+                "OrderServedDate" => $orderServedDate,
             ];
 
             fputcsv($file, $line);

--- a/serve-web/src/Service/ReportService.php
+++ b/serve-web/src/Service/ReportService.php
@@ -110,34 +110,34 @@ class ReportService
     {
         $startDate = new DateTime("2001-01-01 00:00:00");
         $endDate = (new DateTime('now'))->modify('+1 days');
-
-        $orders = $this->getOrders('served', $startDate, $endDate, 1000000);
-
-        $headers = ['CaseNumber', 'OrderType', 'OrderNumber', 'ClientName', 'OrderServedDate'];
-        $ordersCsv = [];
-
-        foreach ($orders as $order) {
-            $ordersCsv[] = [
-                "CaseNumber" => $order->getClient()->getCaseNumber(),
-                "OrderType" => $order->getType(),
-                "OrderNumber" => $order->getOrderNumber(),
-                "ClientName" => $order->getClient()->getClientName(),
-                "OrderMadeDate" => $order->getServedAt()->format('Y-m-d'),
-            ];
-        }
-
         $today = (new DateTime('now'))->format('Y-m-d');
+
         $file = fopen("/tmp/all-served-orders-$today.csv","w");
+
+        $headers = ['OrderId', 'CaseNumber', 'OrderType', 'OrderNumber', 'ClientName', 'OrderServedDate'];
 
         fputcsv($file, $headers);
 
-        foreach($ordersCsv as $line) {
+        $orders = $this->getOrders('served', $startDate, $endDate);
+
+        foreach ($orders as $order) {
+
+            $line = [
+                "OrderId" => $order['id_1'],
+                "CaseNumber" => $order['case_number_13'],
+                "OrderType" => $order['type_16'],
+                "OrderNumber" => $order['order_number_11'],
+                "ClientName" => $order['client_name_14'],
+                "OrderServedDate" => $order['served_at_8'],
+            ];
+
             fputcsv($file, $line);
+
         }
 
-        fclose($file);
+            fclose($file);
 
-        return new File("/tmp/all-served-orders-$today.csv");
+            return new File("/tmp/all-served-orders-$today.csv");
     }
 
     /**
@@ -145,7 +145,7 @@ class ReportService
      *
      * @return Order[]
      */
-    public function getOrders(string $type, DateTime $startDate, DateTime $endDate, int $maxResults): array
+    public function getOrders(string $type, DateTime $startDate, DateTime $endDate): array
     {
         $formattedEndDate = $endDate->format('Y-m-d');
         $formattedStartDate = $startDate->format('Y-m-d');
@@ -155,7 +155,7 @@ class ReportService
             'startDate' => $formattedStartDate,
             'endDate' => $formattedEndDate
         ];
-        return $this->orderRepo->getOrders($filters, $maxResults);
+        return $this->orderRepo->getOrders($filters);
     }
 
 

--- a/serve-web/src/Service/ReportService.php
+++ b/serve-web/src/Service/ReportService.php
@@ -9,13 +9,10 @@ use Symfony\Component\HttpFoundation\File\File;
 
 class ReportService
 {
-    private EntityManagerInterface $em;
-
     private EntityRepository $orderRepo;
 
     public function __construct(EntityManagerInterface $em)
     {
-        $this->em = $em;
         $this->orderRepo = $em->getRepository(Order::class);
     }
 
@@ -114,19 +111,17 @@ class ReportService
         $orders = $this->getOrders('served', $startDate, $endDate);
 
         foreach ($orders as $order) {
-
             $orderServedDate = date('Y-m-d', strtotime($order['served_at_8']));
 
             $line = [
-                "CaseNumber" => $order['case_number_13'],
-                "OrderType" => $order['type_16'],
-                "OrderNumber" => $order['order_number_11'],
-                "ClientName" => $order['client_name_14'],
-                "OrderServedDate" => $orderServedDate,
+                'CaseNumber' => $order['case_number_13'],
+                'OrderType' => $order['type_16'],
+                'OrderNumber' => $order['order_number_11'],
+                'ClientName' => $order['client_name_14'],
+                'OrderServedDate' => $orderServedDate,
             ];
 
             fputcsv($file, $line);
-
         }
 
         fclose($file);

--- a/serve-web/src/Service/ReportService.php
+++ b/serve-web/src/Service/ReportService.php
@@ -72,7 +72,7 @@ class ReportService
         $startDate = new DateTime("2001-01-01 00:00:00");
         $endDate = (new DateTime('now'))->modify('+1 days');
 
-        $orders = $this->getOrders('pending', $startDate, $endDate, 1000000);
+        $orders = $this->getOrders('pending', $startDate, $endDate);
 
         $headers = ['CaseNumber', 'OrderType', 'OrderNumber', 'ClientName', 'OrderMadeDate', 'OrderIssueDate', 'Status' ];
         $ordersCsv = [];
@@ -123,7 +123,6 @@ class ReportService
         foreach ($orders as $order) {
 
             $line = [
-                "OrderId" => $order['id_1'],
                 "CaseNumber" => $order['case_number_13'],
                 "OrderType" => $order['type_16'],
                 "OrderNumber" => $order['order_number_11'],
@@ -145,7 +144,7 @@ class ReportService
      *
      * @return Order[]
      */
-    public function getOrders(string $type, DateTime $startDate, DateTime $endDate): array
+    public function getOrders(string $type, DateTime $startDate, DateTime $endDate, $maxResults = 1000000): array
     {
         $formattedEndDate = $endDate->format('Y-m-d');
         $formattedStartDate = $startDate->format('Y-m-d');
@@ -155,7 +154,13 @@ class ReportService
             'startDate' => $formattedStartDate,
             'endDate' => $formattedEndDate
         ];
-        return $this->orderRepo->getOrders($filters);
+
+        if($type === 'served' && $maxResults === 1000000 ) {
+            return $this->orderRepo->getAllServedOrders($filters);
+        } else {
+            return $this->orderRepo->getOrdersNotServedAndOrderReports($filters, $maxResults);
+        }
+
     }
 
 

--- a/serve-web/src/Service/ReportService.php
+++ b/serve-web/src/Service/ReportService.php
@@ -1,16 +1,10 @@
 <?php
 
-
 namespace App\Service;
 
 use App\Entity\Order;
-use App\Repository\OrderRepository;
-use DateTime;
-use Doctrine\ORM\EntityManager;
 use Doctrine\ORM\EntityManagerInterface;
 use Doctrine\ORM\EntityRepository;
-use DoctrineExtensions\Query\Mysql\Date;
-use phpDocumentor\Reflection\Types\Resource_;
 use Symfony\Component\HttpFoundation\File\File;
 
 class ReportService
@@ -19,7 +13,6 @@ class ReportService
 
     private EntityRepository $orderRepo;
 
-
     public function __construct(EntityManagerInterface $em)
     {
         $this->em = $em;
@@ -27,35 +20,35 @@ class ReportService
     }
 
     /**
-     * Generates a CSV file of served orders for the past 4 weeks
+     * Generates a CSV file of served orders for the past 4 weeks.
      */
     public function generateCsv(): File
     {
-        $endDate = new DateTime('now');
-        $startDate = (new DateTime('now'))->modify('-4 weeks');
+        $endDate = new \DateTime('now');
+        $startDate = (new \DateTime('now'))->modify('-4 weeks');
 
         $orders = $this->getOrders('served', $startDate, $endDate, 10000);
 
-        $headers = ['DateIssued','DateMade', 'DateServed', 'CaseNumber', 'AppointmentType', 'OrderType'];
+        $headers = ['DateIssued', 'DateMade', 'DateServed', 'CaseNumber', 'AppointmentType', 'OrderType'];
         $ordersCsv = [];
 
         foreach ($orders as $order) {
             $ordersCsv[] = [
-                "DateIssued" => $order->getIssuedAt()->format('Y-m-d'),
-                "DateMade" => $order->getMadeAt()->format('Y-m-d'),
-                "DateServed" => $order->getServedAt()->format('Y-m-d'),
-                "CaseNumber" => $order->getClient()->getCaseNumber(),
-                "AppointmentType" => $order->getAppointmentType(),
-                "OrderType" => $order->getType()
+                'DateIssued' => $order->getIssuedAt()->format('Y-m-d'),
+                'DateMade' => $order->getMadeAt()->format('Y-m-d'),
+                'DateServed' => $order->getServedAt()->format('Y-m-d'),
+                'CaseNumber' => $order->getClient()->getCaseNumber(),
+                'AppointmentType' => $order->getAppointmentType(),
+                'OrderType' => $order->getType(),
             ];
         }
 
-        $today = (new DateTime('now'))->format('Y-m-d');
-        $file = fopen("/tmp/orders-served-$today.csv","w");
+        $today = (new \DateTime('now'))->format('Y-m-d');
+        $file = fopen("/tmp/orders-served-$today.csv", 'w');
 
         fputcsv($file, $headers);
 
-        foreach($ordersCsv as $line) {
+        foreach ($ordersCsv as $line) {
             fputcsv($file, $line);
         }
 
@@ -65,36 +58,36 @@ class ReportService
     }
 
     /**
-     * Generates a CSV file of orders waiting to be served
+     * Generates a CSV file of orders waiting to be served.
      */
     public function generateOrdersNotServedCsv(): File
     {
-        $startDate = new DateTime("2001-01-01 00:00:00");
-        $endDate = (new DateTime('now'))->modify('+1 days');
+        $startDate = new \DateTime('2001-01-01 00:00:00');
+        $endDate = (new \DateTime('now'))->modify('+1 days');
 
         $orders = $this->getOrders('pending', $startDate, $endDate);
 
-        $headers = ['CaseNumber', 'OrderType', 'OrderNumber', 'ClientName', 'OrderMadeDate', 'OrderIssueDate', 'Status' ];
+        $headers = ['CaseNumber', 'OrderType', 'OrderNumber', 'ClientName', 'OrderMadeDate', 'OrderIssueDate', 'Status'];
         $ordersCsv = [];
 
         foreach ($orders as $order) {
             $ordersCsv[] = [
-                "CaseNumber" => $order->getClient()->getCaseNumber(),
-                "OrderType" => $order->getType(),
-                "OrderNumber" => $order->getOrderNumber(),
-                "ClientName" => $order->getClient()->getClientName(),
-                "OrderMadeDate" => $order->getMadeAt()->format('Y-m-d'),
-                "OrderIssueDate" => $order->getIssuedAt()->format('Y-m-d'),
-                "Status" => 'READY TO SERVE' ? $order->readyToServe() : 'TO DO',
+                'CaseNumber' => $order->getClient()->getCaseNumber(),
+                'OrderType' => $order->getType(),
+                'OrderNumber' => $order->getOrderNumber(),
+                'ClientName' => $order->getClient()->getClientName(),
+                'OrderMadeDate' => $order->getMadeAt()->format('Y-m-d'),
+                'OrderIssueDate' => $order->getIssuedAt()->format('Y-m-d'),
+                'Status' => 'READY TO SERVE' ? $order->readyToServe() : 'TO DO',
             ];
         }
 
-        $today = (new DateTime('now'))->format('Y-m-d');
-        $file = fopen("/tmp/all-orders-not-served-$today.csv","w");
+        $today = (new \DateTime('now'))->format('Y-m-d');
+        $file = fopen("/tmp/all-orders-not-served-$today.csv", 'w');
 
         fputcsv($file, $headers);
 
-        foreach($ordersCsv as $line) {
+        foreach ($ordersCsv as $line) {
             fputcsv($file, $line);
         }
 
@@ -104,15 +97,15 @@ class ReportService
     }
 
     /**
-     * Generates a CSV file of all served orders
+     * Generates a CSV file of all served orders.
      */
     public function generateAllServedOrdersCsv(): File
     {
-        $startDate = new DateTime("2001-01-01 00:00:00");
-        $endDate = (new DateTime('now'))->modify('+1 days');
-        $today = (new DateTime('now'))->format('Y-m-d');
+        $startDate = new \DateTime('2001-01-01 00:00:00');
+        $endDate = (new \DateTime('now'))->modify('+1 days');
+        $today = (new \DateTime('now'))->format('Y-m-d');
 
-        $file = fopen("/tmp/all-served-orders-$today.csv","w");
+        $file = fopen("/tmp/all-served-orders-$today.csv", 'w');
 
         $headers = ['CaseNumber', 'OrderType', 'OrderNumber', 'ClientName', 'OrderServedDate'];
 
@@ -136,17 +129,17 @@ class ReportService
 
         }
 
-            fclose($file);
+        fclose($file);
 
-            return new File("/tmp/all-served-orders-$today.csv");
+        return new File("/tmp/all-served-orders-$today.csv");
     }
 
     /**
-     *  Get orders that have been served into Sirius using filters
+     *  Get orders that have been served into Sirius using filters.
      *
      * @return Order[]
      */
-    public function getOrders(string $type, DateTime $startDate, DateTime $endDate, $maxResults = 1000000): array
+    public function getOrders(string $type, \DateTime $startDate, \DateTime $endDate, $maxResults = 1000000): array
     {
         $formattedEndDate = $endDate->format('Y-m-d');
         $formattedStartDate = $startDate->format('Y-m-d');
@@ -154,42 +147,40 @@ class ReportService
         $filters = [
             'type' => $type,
             'startDate' => $formattedStartDate,
-            'endDate' => $formattedEndDate
+            'endDate' => $formattedEndDate,
         ];
 
-        if($type === 'served' && $maxResults === 1000000 ) {
+        if ('served' === $type && 1000000 === $maxResults) {
             return $this->orderRepo->getAllServedOrders($filters);
         } else {
             return $this->orderRepo->getOrdersNotServedAndOrderReports($filters, $maxResults);
         }
-
     }
-
 
     /**
      * @return false|resource
      */
     public function getCasesBeforeGoLive()
     {
-        $orders =  $this->orderRepo->getOrdersBeforeGoLive();
+        $orders = $this->orderRepo->getOrdersBeforeGoLive();
 
         $headers = ['DateCreated', 'DateServed', 'CaseNumber', 'OrderType'];
         $ordersCsv = [];
 
         foreach ($orders as $order) {
-            if ($order->getServedAt() === null) {
-                $ordersCsv[] = ["DateCreated" => $order->getCreatedAt()->format('Y-m-d'),
-                    "DateServed" => 'Null',
-                    "CaseNumber" => $order->getClient()->getCaseNumber(),
-                    "OrderType" => $order->getType()];
+            if (null === $order->getServedAt()) {
+                $ordersCsv[] = ['DateCreated' => $order->getCreatedAt()->format('Y-m-d'),
+                    'DateServed' => 'Null',
+                    'CaseNumber' => $order->getClient()->getCaseNumber(),
+                    'OrderType' => $order->getType()];
             }
         }
 
-        $file = fopen("/tmp/cases.csv","w");
+        $file = fopen('/tmp/cases.csv', 'w');
 
         fputcsv($file, $headers);
 
-        foreach($ordersCsv as $line) {
+        foreach ($ordersCsv as $line) {
             fputcsv($file, $line);
         }
 

--- a/serve-web/tests/Service/ReportServiceTest.php
+++ b/serve-web/tests/Service/ReportServiceTest.php
@@ -75,11 +75,11 @@ class ReportServiceTest extends ApiWebTestCase
         $sut = new ReportService($em->reveal());
 
         $expectedCsv = <<<CSV
-DateIssued,DateMade,DateServed,CaseNumber,AppointmentType,OrderType
-$expectedIssuedAt,$expectedMadeAt,$expectedServedAt,$expectedCaseRef,JOINT_AND_SEVERAL,PF
-$expectedIssuedAt,$expectedMadeAt,$expectedServedAt,$expectedCaseRef,SOLE,HW
+        DateIssued,DateMade,DateServed,CaseNumber,AppointmentType,OrderType
+        $expectedIssuedAt,$expectedMadeAt,$expectedServedAt,$expectedCaseRef,JOINT_AND_SEVERAL,PF
+        $expectedIssuedAt,$expectedMadeAt,$expectedServedAt,$expectedCaseRef,SOLE,HW
 
-CSV;
+        CSV;
 
         $actualCsv = $sut->generateCsv();
         $actualCsvString = file_get_contents($actualCsv->getRealPath());
@@ -150,11 +150,16 @@ CSV;
         self::assertEquals(3, $csvRows);
     }
 
-    public function testReportsReturnsAllServedOrders()
+    /**
+     * @test
+     *
+     * @dataProvider numberOfOrders
+     */
+    public function testReportsReturnsAllServedOrders($numberOfOrders, $expectedRows)
     {
         $em = self::getEntityManager();
 
-        $notServedOrders = OrderTestHelper::generateOrders(10, true);
+        $notServedOrders = OrderTestHelper::generateOrders($numberOfOrders, true);
 
         $batchSize = 500;
 
@@ -182,7 +187,16 @@ CSV;
 
         $csvRows = FileTestHelper::countCsvRows($csv->getRealPath(), true);
 
-        self::assertEquals(10, $csvRows);
+        self::assertEquals($expectedRows, $csvRows);
+    }
+
+    public function numberOfOrders()
+    {
+        return [
+            'tenOrders' => [10, 10],
+            'tenThousandOrders' => [10000, 10000],
+            'thirtyThousandOrders' => [30000, 30000],
+        ];
     }
 
     public function testReportsReturnsAllOrdersNotServed()

--- a/serve-web/tests/Service/ReportServiceTest.php
+++ b/serve-web/tests/Service/ReportServiceTest.php
@@ -64,7 +64,7 @@ class ReportServiceTest extends ApiWebTestCase
 
         /** @var ObjectProphecy|OrderRepository $orderRepo */
         $orderRepo = $this->prophesize(OrderRepository::class);
-        $orderRepo->getOrders($filters, 10000)->shouldBeCalled()->willReturn($orders);
+        $orderRepo->getOrdersNotServedAndOrderReports($filters, 10000)->shouldBeCalled()->willReturn($orders);
 
         /** @var ObjectProphecy|EntityManager $em */
         $em = $this->prophesize(EntityManager::class);

--- a/serve-web/tests/Service/ReportServiceTest.php
+++ b/serve-web/tests/Service/ReportServiceTest.php
@@ -1,4 +1,6 @@
-<?php declare(strict_types=1);
+<?php
+
+declare(strict_types=1);
 
 namespace App\Tests\Service;
 
@@ -10,11 +12,11 @@ use App\Service\ReportService;
 use App\TestHelpers\FileTestHelper;
 use App\TestHelpers\OrderTestHelper;
 use App\Tests\ApiWebTestCase;
-use DateTime;
 use Doctrine\ORM\EntityManager;
 use Prophecy\Argument;
-use Prophecy\Prophecy\ObjectProphecy;
 use Prophecy\PhpUnit\ProphecyTrait;
+use Prophecy\Prophecy\ObjectProphecy;
+
 class ReportServiceTest extends ApiWebTestCase
 {
     use ProphecyTrait;
@@ -23,41 +25,41 @@ class ReportServiceTest extends ApiWebTestCase
     {
         $expectedCaseRef = 'COURTREFERENCE1';
 
-        $today = (new DateTime())->format('Y-m-d');
-        $minus4Weeks = (new DateTime())->modify('-4 weeks')->format('Y-m-d');
+        $today = (new \DateTime())->format('Y-m-d');
+        $minus4Weeks = (new \DateTime())->modify('-4 weeks')->format('Y-m-d');
 
         $filters = [
             'type' => 'served',
             'startDate' => $minus4Weeks,
-            'endDate' => $today
+            'endDate' => $today,
         ];
 
         $client = new Client(
             $expectedCaseRef,
             'Client Name',
-            new DateTime()
+            new \DateTime()
         );
 
-        $expectedMadeAt = (new DateTime('now'))->format('Y-m-d');
+        $expectedMadeAt = (new \DateTime('now'))->format('Y-m-d');
         $expectedIssuedAt = '2019-05-23';
         $expectedServedAt = '2019-05-24';
 
         $orderPf = new OrderPf(
             $client,
-            new DateTime($expectedMadeAt),
-            new DateTime($expectedIssuedAt),
+            new \DateTime($expectedMadeAt),
+            new \DateTime($expectedIssuedAt),
             '123'
         );
-        $orderPf->setServedAt(new DateTime($expectedServedAt));
+        $orderPf->setServedAt(new \DateTime($expectedServedAt));
         $orderPf->setAppointmentType('JOINT_AND_SEVERAL');
 
         $orderHw = new OrderHw(
             $client,
-            new DateTime($expectedMadeAt),
-            new DateTime($expectedIssuedAt),
+            new \DateTime($expectedMadeAt),
+            new \DateTime($expectedIssuedAt),
             '124'
         );
-        $orderHw->setServedAt(new DateTime($expectedServedAt));
+        $orderHw->setServedAt(new \DateTime($expectedServedAt));
         $orderHw->setAppointmentType('SOLE');
 
         $orders = [$orderPf, $orderHw];
@@ -86,7 +88,7 @@ CSV;
     }
 
     /**
-     * Includes regression test for ensuring 1000 report limit bug is not re-introduced
+     * Includes regression test for ensuring 1000 report limit bug is not re-introduced.
      */
     public function testCsvLengthEqualsNumberOfCases()
     {
@@ -124,9 +126,9 @@ CSV;
 
         $batchSize = 500;
 
-        $notServedOrders[0]->setServedAt((new DateTime())->modify('-2 weeks'));
-        $notServedOrders[1]->setServedAt((new DateTime())->modify('-3 weeks'));
-        $notServedOrders[2]->setServedAt((new DateTime())->modify('-4 weeks'));
+        $notServedOrders[0]->setServedAt((new \DateTime())->modify('-2 weeks'));
+        $notServedOrders[1]->setServedAt((new \DateTime())->modify('-3 weeks'));
+        $notServedOrders[2]->setServedAt((new \DateTime())->modify('-4 weeks'));
 
         foreach ($notServedOrders as $i => $order) {
             $em->persist($order);
@@ -156,12 +158,12 @@ CSV;
 
         $batchSize = 500;
 
-        $notServedOrders[0]->setServedAt((new DateTime())->modify('-2 weeks'));
-        $notServedOrders[1]->setServedAt((new DateTime())->modify('-3 weeks'));
-        $notServedOrders[2]->setServedAt((new DateTime())->modify('-4 weeks'));
-        $notServedOrders[3]->setServedAt((new DateTime())->modify('-10 weeks'));
-        $notServedOrders[4]->setServedAt((new DateTime())->modify('-1 years'));
-        $notServedOrders[5]->setServedAt((new DateTime())->modify('-4 years'));
+        $notServedOrders[0]->setServedAt((new \DateTime())->modify('-2 weeks'));
+        $notServedOrders[1]->setServedAt((new \DateTime())->modify('-3 weeks'));
+        $notServedOrders[2]->setServedAt((new \DateTime())->modify('-4 weeks'));
+        $notServedOrders[3]->setServedAt((new \DateTime())->modify('-10 weeks'));
+        $notServedOrders[4]->setServedAt((new \DateTime())->modify('-1 years'));
+        $notServedOrders[5]->setServedAt((new \DateTime())->modify('-4 years'));
 
         foreach ($notServedOrders as $i => $order) {
             $em->persist($order);
@@ -191,9 +193,9 @@ CSV;
 
         $batchSize = 500;
 
-        $notServedOrders[0]->setServedAt((new DateTime())->modify('-2 weeks'));
-        $notServedOrders[1]->setServedAt((new DateTime())->modify('-3 weeks'));
-        $notServedOrders[2]->setServedAt((new DateTime())->modify('-4 weeks'));
+        $notServedOrders[0]->setServedAt((new \DateTime())->modify('-2 weeks'));
+        $notServedOrders[1]->setServedAt((new \DateTime())->modify('-3 weeks'));
+        $notServedOrders[2]->setServedAt((new \DateTime())->modify('-4 weeks'));
 
         foreach ($notServedOrders as $i => $order) {
             $em->persist($order);


### PR DESCRIPTION
## Description
Apply fix to prevent the 'All Served Orders' report from timing out due to the large data set fetched when generating the CSV

The fix was to fetch the data as an associative array instead of objects for this specific report.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Issues Resolved

SER-XXX [List any existing issues this PR resolves]

## Merge check List

- [ ] New functionality includes testing
- [ ] New functionality has been documented in the README if applicable
- [ ] Approved by PMs
