### PR TITLE
Small amount of Deprecation Updates for Symfony6

### DIFF
--- a/serve-web/src/Controller/BehatController.php
+++ b/serve-web/src/Controller/BehatController.php
@@ -21,7 +21,8 @@ use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\HttpKernel\KernelInterface;
 use Symfony\Component\Routing\Annotation\Route;
-use Symfony\Component\Security\Core\Encoder\UserPasswordEncoderInterface;
+//use Symfony\Component\Security\Core\Encoder\UserPasswordEncoderInterface;
+use Symfony\Component\PasswordHasher\Hasher\UserPasswordHasherInterface; // New with Symfony 6
 
 #[Route(path: '/behat')]
 class BehatController extends AbstractController
@@ -42,7 +43,8 @@ class BehatController extends AbstractController
 
     private OrderService $orderService;
 
-    private UserPasswordEncoderInterface $encoder;
+    //private UserPasswordEncoderInterface $encoder;
+    private UserPasswordHasherInterface $hasher;
 
     private UserProvider $userProvider;
 
@@ -58,14 +60,14 @@ class BehatController extends AbstractController
         EntityManager $em,
         ClientService $clientService,
         OrderService $orderService,
-        UserPasswordEncoderInterface $encoder,
+        UserPasswordHasherInterface $hasher, //Changed because of deprecation to Symfony6
         UserProvider $userProvider
     )
     {
         $this->em = $em;
         $this->clientService = $clientService;
         $this->orderService = $orderService;
-        $this->encoder = $encoder;
+        $this->hasher = $hasher; // see above
         $this->userProvider = $userProvider;
         $this->behatPassword = getenv("BEHAT_PASSWORD");
     }
@@ -105,7 +107,8 @@ class BehatController extends AbstractController
             }
 
 
-            $encodedPassword = $this->encoder->encodePassword($user, $this->behatPassword);
+            //$encodedPassword = $this->encoder->encodePassword($user, $this->behatPassword);
+            $encodedPassword = $this->hasher->hashPassword($user, $this->behatPassword);
             $user->setPassword($encodedPassword);
 
             $this->em->flush();

--- a/serve-web/src/Controller/UserController.php
+++ b/serve-web/src/Controller/UserController.php
@@ -43,7 +43,7 @@ class UserController extends AbstractController
 
         return $this->render('User/login.html.twig', array(
             'error' => $error,
-            'lockedForSeconds' => $error && ($token = $error->getToken()) && ($username = $token->getUsername())
+            'lockedForSeconds' => $error && ($token = $error->getToken()) && ($username = $token->getUsername()) // This function will need to be changed to getUserIdentifier for Symfony version 6 and above
                 ? $up->usernameLockedForSeconds($username)
                 : false
         ));

--- a/serve-web/src/Entity/User.php
+++ b/serve-web/src/Entity/User.php
@@ -6,11 +6,12 @@ use Serializable;
 use Doctrine\ORM\Mapping as ORM;
 use Symfony\Component\Security\Core\User\UserInterface;
 use Symfony\Component\Security\Core\User\EquatableInterface;
+use Symfony\Component\Security\Core\User\PasswordAuthenticatedUserInterface;
 
 #[ORM\Table(name: 'dc_user')]
 #[ORM\Entity(repositoryClass: 'App\Repository\UserRepository')]
 #[ORM\HasLifecycleCallbacks]
-class User implements UserInterface, EquatableInterface
+class User implements UserInterface, EquatableInterface, PasswordAuthenticatedUserInterface
 {
     /**
      * @var string
@@ -107,11 +108,16 @@ class User implements UserInterface, EquatableInterface
         return '';
     }
 
-    public function getUsername(): ?string
+    public function getUsername(): string //This function has been replaced with getUserIdentifier() and will need to be updated for Symfony version 6 and above
     {
         return $this->email;
     }
 
+    public function getUserIdentifier(): string 
+    {
+        return (string) $this->email;
+    }
+    
     public function isEqualTo(UserInterface $user): bool
     {
         if (!$user instanceof User) {

--- a/serve-web/src/Service/Security/LoginAttempts/UserProvider.php
+++ b/serve-web/src/Service/Security/LoginAttempts/UserProvider.php
@@ -52,7 +52,7 @@ class UserProvider implements UserProviderInterface
         return $waits ? max($waits) : false;
     }
 
-    public function loadUserByUsername($username): User
+    public function loadUserByUsername($username): User // This needs to be changed to loadUserByIdentifier
     {
         if (empty($username)) {
             throw new UsernameNotFoundException('Missing username');

--- a/serve-web/tests/EventListener/SuccessfulAuthenticationListenerTest.php
+++ b/serve-web/tests/EventListener/SuccessfulAuthenticationListenerTest.php
@@ -34,6 +34,7 @@ class SuccessfulAuthenticationListenerTest extends TestCase
         $entityManager->flush()->shouldBeCalled();
 
         $dummyToken = new UsernamePasswordToken($expectedUserModel, 'bar', 'key');
+
         $authenticationEvent = new AuthenticationEvent($dummyToken);
 
         $eventListener = new SuccessfulAuthenticationListener($entityManager->reveal());

--- a/serve-web/tests/Service/UserProviderTest.php
+++ b/serve-web/tests/Service/UserProviderTest.php
@@ -64,7 +64,7 @@ class UserProviderTest extends MockeryTestCase
 
         $this->userRepo->shouldReceive('findOneBy')->once()->with(['email' => $this->userName])->andReturn($this->user);
 
-        $this->assertEquals($this->user, $sut->loadUserByUsername($this->userName));
+        $this->assertEquals($this->user, $sut->loadUserByUsername($this->userName)); // This needs to be changed to loadUserByIdentifier
     }
 
     public function testEmptyConfigLoadMissingUserThrowsException()
@@ -74,7 +74,7 @@ class UserProviderTest extends MockeryTestCase
         $this->userRepo->shouldReceive('findOneBy')->once()->with(['email' => 'nonExisting@provider.com'])->andReturn(false);
 
         $this->expectException(UsernameNotFoundException::class);
-        $this->assertEquals($this->user, $sut->loadUserByUsername('nonExisting@provider.com'));
+        $this->assertEquals($this->user, $sut->loadUserByUsername('nonExisting@provider.com')); //This needs to be changed to loadUserByIdentifier
     }
 
     public function testBruteForceLockNotReached()
@@ -86,7 +86,7 @@ class UserProviderTest extends MockeryTestCase
 
         $this->userRepo->shouldReceive('findOneBy')->once()->with(['email' => $this->userName])->andReturn($this->user);
 
-        $this->assertEquals($this->user, $sut->loadUserByUsername($this->userName));
+        $this->assertEquals($this->user, $sut->loadUserByUsername($this->userName)); //This needs to be changed to loadUserByIdentifier
     }
 
     public function testBruteForceLockReached()
@@ -99,7 +99,7 @@ class UserProviderTest extends MockeryTestCase
         $this->expectException(BruteForceAttackDetectedException::class);
         $this->userRepo->shouldReceive('findOneBy')->never()->with(['email' => $this->userName]);
 
-        $sut->loadUserByUsername($this->userName);
+        $sut->loadUserByUsername($this->userName); //This needs to be changed to loadUserByIdentifier
 
         $this->assertEquals(200, $this->getExpectedException()->getHasToWaitForSeconds());
     }


### PR DESCRIPTION
Replaced UserPasswordEncoderInterface with UserPasswordHasherInterface.

Updated BehatController to use the new hasher instead of the encoder.

Added comments to prepare for getUserIdentifier change, needing the future reformating of that code.

