### PR TITLE
DDLS-766 report timeout

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -58,7 +58,7 @@ up-test: ##@application Brings the app up in test mode with profiler and xdebug 
 	docker compose -f docker-compose.yml -f docker-compose.test.yml run --rm app php bin/console cache:clear --env=test
 
 unit-tests: up-test ##@testing Requires the app to be built and up before running
-	docker compose -f docker-compose.yml -f docker-compose.test.yml run app php bin/phpunit --testdox tests $(args)
+	docker compose -f docker-compose.yml -f docker-compose.test.yml run app php ./vendor/bin/phpunit --testdox tests $(args)
 
 behat-tests: up-test ##@testing Requires the app to be built and up before running
 	docker compose -f docker-compose.yml -f docker-compose.test.yml run behat --suite=local

--- a/serve-web/docker/app/Dockerfile
+++ b/serve-web/docker/app/Dockerfile
@@ -37,11 +37,6 @@ RUN php composer-setup.php --version=2.6.6
 RUN php -r "unlink('composer-setup.php');"
 RUN mv composer.phar /usr/local/bin/composer
 
-#PHPUNIT
-RUN composer global require "phpunit/phpunit"
-
-ENV PATH /root/.composer/vendor/bin:$PATH
-
 WORKDIR /var/www
 
 RUN mkdir -p tmp/screenshots

--- a/serve-web/src/Common/Query/QueryPager.php
+++ b/serve-web/src/Common/Query/QueryPager.php
@@ -1,0 +1,65 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Common\Query;
+
+use Doctrine\ORM\NonUniqueResultException;
+use Doctrine\ORM\NoResultException;
+use Doctrine\ORM\Query;
+
+/**
+ * Create a generator from a pair of queries: the first which gets the size of the result set, and
+ * the second which gets the data.
+ *
+ * Results are returned
+ */
+class QueryPager
+{
+    public function __construct(
+        // this should return a single row with a single column containing the count of rows in the resultset,
+        // amenable to being called with getSingleScalarResult()
+        private readonly Query $countQuery,
+
+        // query to get a page from the resultset
+        private readonly Query $pageQuery,
+    ) {
+    }
+
+    /**
+     * Return rows from the $pagedQuery as an array of arrays; each element is a row in format [<field> => <value>, ...].
+     *
+     * Set $asArray = false to get objects back (type depends on the $pageQuery); otherwise, this returns array results
+     *
+     * @return \Traversable<array<string, mixed>>|\Traversable<object>
+     *
+     * @throws NonUniqueResultException
+     * @throws NoResultException
+     */
+    public function getRows(int $pageSize = 1000, bool $asArray = true): \Traversable
+    {
+        /** @var int $numRows */
+        $numRows = $this->countQuery->getSingleScalarResult();
+
+        $numPages = ceil($numRows / $pageSize);
+
+        $currentPage = 1;
+        while ($numPages >= $currentPage) {
+            $pagedQuery = $this->pageQuery->setFirstResult(($currentPage - 1) * $pageSize)->setMaxResults($pageSize);
+
+            if ($asArray) {
+                /** @var iterable<array<string, mixed>> $rows */
+                $rows = $pagedQuery->getArrayResult();
+            } else {
+                /** @var iterable<object> $rows */
+                $rows = $pagedQuery->getResult();
+            }
+
+            foreach ($rows as $row) {
+                yield $row;
+            }
+
+            ++$currentPage;
+        }
+    }
+}

--- a/serve-web/src/Common/Query/QueryPager.php
+++ b/serve-web/src/Common/Query/QueryPager.php
@@ -36,10 +36,18 @@ class QueryPager
      * @throws NonUniqueResultException
      * @throws NoResultException
      */
-    public function getRows(int $pageSize = 1000, bool $asArray = true): \Traversable
+    public function getRows(int $pageSize = 1000, bool $asArray = true, int $limit = 0): \Traversable
     {
         /** @var int $numRows */
         $numRows = $this->countQuery->getSingleScalarResult();
+
+        if ($limit > 0 && $numRows > $limit) {
+            $numRows = $limit;
+        }
+
+        if ($limit > 0 && $pageSize > $limit) {
+            $pageSize = $limit;
+        }
 
         $numPages = ceil($numRows / $pageSize);
 

--- a/serve-web/src/Controller/CaseController.php
+++ b/serve-web/src/Controller/CaseController.php
@@ -3,8 +3,8 @@
 namespace App\Controller;
 
 use App\Entity\Order;
+use App\Repository\OrderRepository;
 use Doctrine\ORM\EntityManager;
-use Doctrine\Persistence\ObjectRepository;
 use Symfony\Bundle\FrameworkBundle\Controller\AbstractController;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
@@ -13,28 +13,29 @@ use Symfony\Component\Routing\Annotation\Route;
 #[Route(path: '/case')]
 class CaseController extends AbstractController
 {
-    private ObjectRepository $orderRepo;
+    private OrderRepository $orderRepo;
 
     /**
      * UserController constructor.
      */
     public function __construct(EntityManager $em)
     {
-        $this->orderRepo = $em->getRepository(Order::class);
+        /** @var OrderRepository $repo */
+        $repo = $em->getRepository(Order::class);
+
+        $this->orderRepo = $repo;
     }
 
     #[Route(path: '', name: 'case-list')]
     public function indexAction(Request $request): Response
     {
-        $limit = 50;
-
         $filters = [
             'type' => $request->get('type', 'pending'),
             'q' => $request->get('q', ''),
         ];
 
         return $this->render('Case/index.html.twig', [
-            'orders' => $this->orderRepo->getOrdersNotServedAndOrderReports($filters, $limit),
+            'orders' => iterator_to_array($this->orderRepo->getOrders($filters, limit: 50, asArray: false)),
             'filters' => $filters,
             'counts' => [
                 'pending' => $this->orderRepo->getOrdersCount(['type' => 'pending'] + $filters),

--- a/serve-web/src/Controller/ReportController.php
+++ b/serve-web/src/Controller/ReportController.php
@@ -28,7 +28,7 @@ class ReportController extends AbstractController
     #[Route(path: '/download', name: 'download-report')]
     public function downloadReportAction(): BinaryFileResponse
     {
-        $csv = $this->reportService->generateCsv();
+        $csv = $this->reportService->generateLast4WeeksCsv();
 
         return $this->file($csv);
     }

--- a/serve-web/src/Repository/OrderRepository.php
+++ b/serve-web/src/Repository/OrderRepository.php
@@ -21,10 +21,11 @@ class OrderRepository extends EntityRepository
         return $qb->getQuery()->getSingleScalarResult();
     }
 
-    // Function is using the same query builder as 'getOrdersNotServedAndOrderReports' but instead fetching data back as an associative array to handle large dataset and avoid timeouts
-    public function getAllServedOrders(array $filters, int $maxResults = 1000000)
+    // Function is using the same query builder as 'getOrdersNotServedAndOrderReports' but instead
+    // fetching data back as an associative array to handle large dataset and avoid timeouts
+    public function getAllServedOrders(array $filters)
     {
-        $queryBuilder = $this->createOrdersQueryBuilder($filters, $maxResults);
+        $queryBuilder = $this->createOrdersQueryBuilder($filters);
 
         $rawParams = $queryBuilder->getParameters();
 
@@ -40,24 +41,23 @@ class OrderRepository extends EntityRepository
         return $stmt->fetchAllAssociative();
     }
 
-    public function getOrdersNotServedAndOrderReports(array $filters, int $maxResults)
+    public function getOrdersNotServedAndOrderReports(array $filters)
     {
-        $queryBuilder = $this->createOrdersQueryBuilder($filters, $maxResults);
+        $queryBuilder = $this->createOrdersQueryBuilder($filters);
 
         return $queryBuilder->getQuery()->getResult();
     }
 
-    private function createOrdersQueryBuilder(array $filters, int $maxResults): QueryBuilder
+    private function createOrdersQueryBuilder(array $filters): QueryBuilder
     {
         /**
          * If the order is served, we order using the inverse (-) servedBy date, otherwise we use the issued date.
          * Negative dates as a integer result in a custom ordering field allow different ordering on the two order tabs,
-         * (served and pending)
+         * (served and pending).
          */
-
         $qb = $this->_em->getRepository(Order::class)
             ->createQueryBuilder('o')
-            ->select("o, c")
+            ->select('o, c')
             ->addSelect("
                 (
                     CASE WHEN (o.servedAt IS NULL) THEN
@@ -72,8 +72,7 @@ class OrderRepository extends EntityRepository
             ) AS HIDDEN custom_ordering
         ")
         ->leftJoin('o.client', 'c')
-        ->orderBy('custom_ordering', 'ASC')
-        ->setMaxResults($maxResults);
+        ->orderBy('custom_ordering', 'ASC');
 
         $this->applyFilters($qb, $filters);
 

--- a/serve-web/src/Service/ReportService.php
+++ b/serve-web/src/Service/ReportService.php
@@ -19,7 +19,7 @@ class ReportService
     /**
      * Generates a CSV file of served orders for the past 4 weeks.
      */
-    public function generateCsv(): File
+    public function generateLast4WeeksCsv(): File
     {
         $endDate = new \DateTime('now');
         $startDate = (new \DateTime('now'))->modify('-4 weeks');
@@ -100,15 +100,16 @@ class ReportService
 
         $orders = $this->getOrders('served', $startDate, $endDate);
 
+        /** @var Order $order */
         foreach ($orders as $order) {
             fputcsv($file, [
-                'DateIssued' => $order['issued_at_7'],
-                'DateMade' => $order['made_at_6'],
-                'CaseNumber' => $order['case_number_13'],
-                'OrderType' => $order['type_16'],
-                'OrderNumber' => $order['order_number_11'],
-                'ClientName' => $order['client_name_14'],
-                'OrderServedDate' => $order['served_at_8'],
+                'DateIssued' => $order['issuedAt']?->format('Y-m-d'),
+                'DateMade' => $order['madeAt']?->format('Y-m-d'),
+                'CaseNumber' => $order['client']['caseNumber'],
+                'OrderType' => $order['type'],
+                'OrderNumber' => $order['orderNumber'],
+                'ClientName' => $order['client']['clientName'],
+                'OrderServedDate' => $order['servedAt']?->format('Y-m-d'),
             ]);
         }
 

--- a/serve-web/src/Service/ReportService.php
+++ b/serve-web/src/Service/ReportService.php
@@ -3,17 +3,22 @@
 namespace App\Service;
 
 use App\Entity\Order;
+use App\Repository\OrderRepository;
 use Doctrine\ORM\EntityManagerInterface;
-use Doctrine\ORM\EntityRepository;
+use Doctrine\ORM\NonUniqueResultException;
+use Doctrine\ORM\NoResultException;
 use Symfony\Component\HttpFoundation\File\File;
 
 class ReportService
 {
-    private EntityRepository $orderRepo;
+    private OrderRepository $orderRepo;
 
     public function __construct(EntityManagerInterface $em)
     {
-        $this->orderRepo = $em->getRepository(Order::class);
+        /** @var OrderRepository $repo */
+        $repo = $em->getRepository(Order::class);
+
+        $this->orderRepo = $repo;
     }
 
     /**
@@ -24,7 +29,7 @@ class ReportService
         $endDate = new \DateTime('now');
         $startDate = (new \DateTime('now'))->modify('-4 weeks');
 
-        $orders = $this->getOrders('served-last-4-weeks', $startDate, $endDate);
+        $orders = $this->getFilteredOrders('served-last-4-weeks', $startDate, $endDate);
 
         $headers = ['DateIssued', 'DateMade', 'DateServed', 'CaseNumber', 'AppointmentType', 'OrderType'];
 
@@ -35,12 +40,12 @@ class ReportService
 
         foreach ($orders as $order) {
             fputcsv($file, [
-                'DateIssued' => $order->getIssuedAt()->format('Y-m-d'),
-                'DateMade' => $order->getMadeAt()->format('Y-m-d'),
-                'DateServed' => $order->getServedAt()?->format('Y-m-d'),
-                'CaseNumber' => $order->getClient()->getCaseNumber(),
-                'AppointmentType' => $order->getAppointmentType(),
-                'OrderType' => $order->getType(),
+                'DateIssued' => $order['issuedAt']?->format('Y-m-d'),
+                'DateMade' => $order['madeAt']?->format('Y-m-d'),
+                'DateServed' => $order['servedAt']?->format('Y-m-d'),
+                'CaseNumber' => $order['client']['caseNumber'],
+                'AppointmentType' => $order['appointmentType'],
+                'OrderType' => $order['type'],
             ]);
         }
 
@@ -57,7 +62,7 @@ class ReportService
         $startDate = new \DateTime('2001-01-01 00:00:00');
         $endDate = (new \DateTime('now'))->modify('+1 days');
 
-        $orders = $this->getOrders('pending', $startDate, $endDate);
+        $orders = $this->getFilteredOrders('pending', $startDate, $endDate, asArray: false);
 
         $headers = ['CaseNumber', 'OrderType', 'OrderNumber', 'ClientName', 'OrderMadeDate', 'OrderIssueDate', 'Status'];
 
@@ -66,6 +71,7 @@ class ReportService
 
         fputcsv($file, $headers);
 
+        /** @var Order $order */
         foreach ($orders as $order) {
             fputcsv($file, [
                 'CaseNumber' => $order->getClient()->getCaseNumber(),
@@ -98,7 +104,7 @@ class ReportService
 
         fputcsv($file, $headers);
 
-        $orders = $this->getOrders('served', $startDate, $endDate);
+        $orders = $this->getFilteredOrders('served', $startDate, $endDate);
 
         /** @var Order $order */
         foreach ($orders as $order) {
@@ -119,24 +125,28 @@ class ReportService
     }
 
     /**
-     *  Get orders that have been served into Sirius.
+     * Get orders that have been served into Sirius.
+     *
+     * @throws NoResultException
+     * @throws NonUniqueResultException
      */
-    public function getOrders(string $type, \DateTime $startDate, \DateTime $endDate): iterable
+    public function getFilteredOrders(string $type, \DateTime $startDate, \DateTime $endDate, bool $asArray = true): \Traversable
     {
         $formattedEndDate = $endDate->format('Y-m-d');
         $formattedStartDate = $startDate->format('Y-m-d');
 
+        $typeFilter = 'served';
+        if ('pending' == $type) {
+            $typeFilter = 'pending';
+        }
+
         $filters = [
-            'type' => $type,
+            'type' => $typeFilter,
             'startDate' => $formattedStartDate,
             'endDate' => $formattedEndDate,
         ];
 
-        if ('served' === $type) {
-            return $this->orderRepo->getAllServedOrders($filters);
-        } else {
-            return $this->orderRepo->getOrdersNotServedAndOrderReports($filters);
-        }
+        return $this->orderRepo->getOrders($filters, asArray: $asArray);
     }
 
     /**

--- a/serve-web/tests/Service/ReportServiceTest.php
+++ b/serve-web/tests/Service/ReportServiceTest.php
@@ -81,7 +81,7 @@ class ReportServiceTest extends ApiWebTestCase
 
         CSV;
 
-        $actualCsv = $sut->generateCsv();
+        $actualCsv = $sut->generateLast4WeeksCsv();
         $actualCsvString = file_get_contents($actualCsv->getRealPath());
 
         self::assertEquals($expectedCsv, $actualCsvString);
@@ -111,7 +111,7 @@ class ReportServiceTest extends ApiWebTestCase
         $em->clear();
 
         $sut = new ReportService($em);
-        $csv = $sut->generateCsv();
+        $csv = $sut->generateLast4WeeksCsv();
 
         $csvRows = FileTestHelper::countCsvRows($csv->getRealPath(), true);
 
@@ -143,7 +143,7 @@ class ReportServiceTest extends ApiWebTestCase
         $em->clear();
 
         $sut = new ReportService($em);
-        $csv = $sut->generateCsv();
+        $csv = $sut->generateLast4WeeksCsv();
 
         $csvRows = FileTestHelper::countCsvRows($csv->getRealPath(), true);
 

--- a/serve-web/tests/Service/ReportServiceTest.php
+++ b/serve-web/tests/Service/ReportServiceTest.php
@@ -152,16 +152,16 @@ class ReportServiceTest extends ApiWebTestCase
     protected function numberOfOrdersDataProvider()
     {
         return [
-            'tenOrders' => [10, 10],
-            'tenThousandOrders' => [10000, 10000],
-            'thirtyThousandOrders' => [30000, 30000],
+            'tenOrders' => [10],
+            'tenThousandOrders' => [10000],
+            'thirtyThousandOrders' => [30000],
         ];
     }
 
     /**
      * @dataProvider numberOfOrdersDataProvider
      */
-    public function testReportsReturnsAllServedOrders($numberOfOrders, $expectedRows)
+    public function testReportsReturnsAllServedOrders($numberOfOrders)
     {
         $em = self::getEntityManager();
 
@@ -193,7 +193,7 @@ class ReportServiceTest extends ApiWebTestCase
 
         $csvRows = FileTestHelper::countCsvRows($csv->getRealPath(), true);
 
-        self::assertEquals($expectedRows, $csvRows);
+        self::assertEquals($numberOfOrders, $csvRows);
     }
 
     public function testReportsReturnsAllOrdersNotServed()


### PR DESCRIPTION
## Description

* Use a pager to stream results to caller (1000 at a time)
* Write CSV lines as each record is returned, rather than collecting into array first
* Remove all maxResults parameters, which seem to only be there to prevent queries from timing out

Tested "all served orders" query with 200,000 orders in db.

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Issues Resolved

DDLS-766

## Merge check List

- [ ] New functionality includes testing
- [ ] New functionality has been documented in the README if applicable
- [ ] Approved by PMs
