### PR TITLE
Dockerise Behat tests

### DIFF
--- a/.github/workflows/_tests-behat.yml
+++ b/.github/workflows/_tests-behat.yml
@@ -41,11 +41,6 @@ jobs:
 
       - uses: unfor19/install-aws-cli-action@f5b46b7f32cf5e7ebd652656c5036bf83dd1e60c # v1
 
-      - name: Install PHP 8.4
-        uses: shivammathur/setup-php@bf6b4fbd49ca58e4608c9c89fba0b8d90bd2a39f # 2.35.5
-        with:
-          php-version: "8.4.8"
-
       - name: Set up Python
         uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5.6.0
         with:
@@ -59,27 +54,6 @@ jobs:
       - name: Install Python packages
         run: |
           pip3 install -r scripts/ci_ingress/requirements.txt
-
-      - name: Get Composer Cache Directory
-        id: composer-cache
-        run: |
-          echo "dir=$(composer config cache-files-dir)" >> "$GITHUB_OUTPUT"
-        working-directory: ./serve-web
-
-      - name: Cache PHP Dependencies
-        uses: actions/cache@0400d5f644dc74513175e3cd8d07132dd4860809 # v4.2.4
-        with:
-          path: ${{ steps.composer-cache.outputs.dir }}
-          key: ${{ runner.os }}-composer-${{ hashFiles('**/composer.lock') }}
-          restore-keys: |
-            ${{ runner.os }}-composer-
-
-      - name: Composer Install
-        env:
-          ENVIRONMENT_NAME: development
-        run: |
-          composer install --no-interaction
-        working-directory: ./serve-web
 
       - name: Create Failure Folder
         run: |
@@ -117,7 +91,8 @@ jobs:
           SIRIUS_S3_BUCKET_NAME: ${{ inputs.sirius_api_bucket }}
           ENVIRONMENT_NAME: development
         run: |
-          vendor/bin/behat --stop-on-failure -c behat.yml.dist ${{ inputs.suite }}
+          docker compose run --rm --entrypoint="composer install --prefer-dist --no-interaction --no-scripts --optimize-autoloader" behat
+          docker compose run --rm --env APP_VERSION --env BEHAT_PARAMS --env ENVIRONMENT_NAME --env SIRIUS_S3_BUCKET_NAME behat ${{ inputs.suite }}
         working-directory: ./serve-web
 
       - name: Archive Test Output


### PR DESCRIPTION
## Description

We want to stop using `shivammathur/setup-php` to run PHP directly on runners, and instead to use docker containers.

Using the existing “behat” docker service, install dev dependencies and then run behat.

Fixes SER-237 #patch

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Issues Resolved

SER-237

## Merge check List

- [ ] New functionality includes testing
- [ ] New functionality has been documented in the README if applicable
- [ ] Approved by PMs
