### PR TITLE
DDLS-1343 recreate pre in the new network

### DIFF
--- a/.github/workflows/workflow-pull-request-path.yml
+++ b/.github/workflows/workflow-pull-request-path.yml
@@ -173,7 +173,7 @@ jobs:
       suite: --suite=${{ needs.workflow_variables.outputs.suite }}
       account_name: ${{ needs.workflow_variables.outputs.account_name }}
       account_id: ${{ needs.workflow_variables.outputs.account_id }}
-      vpc_scope: ${{ needs.workflow_variables.outputs.build_identifier == 'preproduction' && 'main' || 'serveopg' }}
+      vpc_scope: serveopg
 
   create_tag_release:
     if: github.event_name == 'merge_group'

--- a/terraform/environment/rds.tf
+++ b/terraform/environment/rds.tf
@@ -59,6 +59,10 @@ data "aws_kms_key" "rds" {
   key_id = "alias/aws/rds"
 }
 
+data "aws_kms_alias" "rds_encryption_key" {
+  name = "alias/serve_rds_encryption_key"
+}
+
 resource "aws_rds_cluster" "cluster_serverless" {
   cluster_identifier                  = "serve-opg-${local.environment}-cluster"
   apply_immediately                   = local.account.deletion_protection ? false : true
@@ -72,7 +76,7 @@ resource "aws_rds_cluster" "cluster_serverless" {
   engine_version                      = local.account.postgres_version
   engine_mode                         = "provisioned"
   final_snapshot_identifier           = "serve-opg-${local.environment}-final-snapshot"
-  kms_key_id                          = data.aws_kms_key.rds.arn
+  kms_key_id                          = local.account.use_rds_cmk ? data.aws_kms_alias.rds_encryption_key.target_key_arn : data.aws_kms_key.rds.arn
   master_username                     = "serveopgadmin"
   master_password                     = data.aws_secretsmanager_secret_version.database_password.secret_string
   preferred_backup_window             = "05:15-05:45"
@@ -104,7 +108,7 @@ resource "aws_rds_cluster_instance" "serverless_instances" {
   monitoring_interval             = 30
   monitoring_role_arn             = "arn:aws:iam::${local.account.account_id}:role/rds-enhanced-monitoring"
   performance_insights_enabled    = true
-  performance_insights_kms_key_id = data.aws_kms_key.rds.arn
+  performance_insights_kms_key_id = local.account.use_rds_cmk ? data.aws_kms_alias.rds_encryption_key.target_key_arn : data.aws_kms_key.rds.arn
   ca_cert_identifier              = "rds-ca-rsa2048-g1"
   publicly_accessible             = false
   tags                            = local.default_tags

--- a/terraform/environment/terraform.tfvars.json
+++ b/terraform/environment/terraform.tfvars.json
@@ -19,7 +19,8 @@
       "cloud9_env_id": "bf29747db5624ba9b8cc432e0150bbfc",
       "use_event_bus": "false",
       "dr_backup": "true",
-      "use_new_network": false
+      "use_new_network": false,
+      "use_rds_cmk": false
     },
     "preproduction": {
       "account_id": "540070264006",
@@ -40,7 +41,8 @@
       "cloud9_env_id": "65fc332fdb7e4ef98923dc47ef3fb1f4",
       "use_event_bus": "false",
       "dr_backup": "true",
-      "use_new_network": false
+      "use_new_network": true,
+      "use_rds_cmk": true
     },
     "default": {
       "account_id": "705467933182",
@@ -61,7 +63,8 @@
       "cloud9_env_id": "8aca4c4f8c7545ffa4e2a999ae17101a",
       "use_event_bus": "false",
       "dr_backup": "false",
-      "use_new_network": true
+      "use_new_network": true,
+      "use_rds_cmk": true
     }
   }
 }

--- a/terraform/environment/variables.tf
+++ b/terraform/environment/variables.tf
@@ -24,6 +24,7 @@ variable "accounts" {
       use_event_bus             = string
       dr_backup                 = string
       use_new_network           = bool
+      use_rds_cmk               = bool
     })
   )
 }


### PR DESCRIPTION
Will have to manually destroy the preproduction environment before merging but then it will be recreated in the new network with a customer managed key on the DB.