### PR TITLE
DDLS-1343 add preproduction to shared firewall

### DIFF
--- a/terraform/account/network.tf
+++ b/terraform/account/network.tf
@@ -121,13 +121,13 @@ locals {
       }
     }
     preproduction = {
-      network_firewall_enabled      = false
-      none_matching_traffic_action  = "alert"
-      shared_firewall_configuration = null
-      #      shared_firewall_configuration = {
-      #        account_id   = "679638075911"
-      #        account_name = "production"
-      #      }
+      network_firewall_enabled     = true
+      none_matching_traffic_action = "alert"
+      #      shared_firewall_configuration = null
+      shared_firewall_configuration = {
+        account_id   = "997462338508"
+        account_name = "production"
+      }
     }
     production = {
       network_firewall_enabled      = false


### PR DESCRIPTION
Final bit to add preproduction into the shared firewall. 

Pre is now on the new network and just needs to be modified so that it is added into the shared firewall.